### PR TITLE
GraphQL subscription support for synchronous webhook events

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -54,6 +54,7 @@ from .dataloaders import (
     CheckoutLinesInfoByCheckoutTokenLoader,
     TransactionItemsByCheckoutIDLoader,
 )
+from .utils import prevent_sync_event_circular_query
 
 
 class GatewayConfigLine(graphene.ObjectType):
@@ -493,6 +494,7 @@ class Checkout(ModelObjectType):
 
     @classmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_shipping_methods(cls, root: models.Checkout, info):
         return (
             CheckoutInfoByCheckoutTokenLoader(info.context)
@@ -610,6 +612,7 @@ class Checkout(ModelObjectType):
 
     @staticmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     def resolve_available_shipping_methods(root: models.Checkout, info):
         return (
             CheckoutInfoByCheckoutTokenLoader(info.context)
@@ -630,6 +633,7 @@ class Checkout(ModelObjectType):
         )
 
     @staticmethod
+    @prevent_sync_event_circular_query
     def resolve_available_payment_gateways(root: models.Checkout, info):
         return info.context.plugins.list_payment_gateways(
             currency=root.currency, checkout=root, channel_slug=root.channel.slug

--- a/saleor/graphql/checkout/utils.py
+++ b/saleor/graphql/checkout/utils.py
@@ -1,5 +1,8 @@
 import graphene
 from django.core.exceptions import ValidationError
+from graphql import ResolveInfo
+
+from ...core.exceptions import CircularSubscriptionSyncEvent
 
 
 def prepare_insufficient_stock_checkout_validation_error(exc):
@@ -13,3 +16,25 @@ def prepare_insufficient_stock_checkout_validation_error(exc):
         code=exc.code.value,
         params={"variants": variant_ids},
     )
+
+
+def prevent_sync_event_circular_query(func):
+    """Prevent circular dependencies in synchronous events resolvers.
+
+    Synchronous events are not allowed to request fields that are resolved using other
+    synchronous events, which would lead to circular calls of the webhook.
+    Using this decorator prevents such circular events resolution.
+
+    :raises CircularSubscriptionSyncEvent: When a field being resolved from a
+    synchronous webhook's payload uses another synchronous webhook internally.
+    """
+
+    def wrapper(*args, **kwargs):
+        info = next(arg for arg in args if isinstance(arg, ResolveInfo))
+        if getattr(info.context, "sync_event", False):
+            raise CircularSubscriptionSyncEvent(
+                "Resolving this field is not allowed in synchronous events."
+            )
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -58,6 +58,7 @@ from ..app.types import App
 from ..channel import ChannelContext
 from ..channel.dataloaders import ChannelByIdLoader, ChannelByOrderLineIdLoader
 from ..channel.types import Channel
+from ..checkout.utils import prevent_sync_event_circular_query
 from ..core.connection import CountableConnection
 from ..core.descriptions import (
     ADDED_IN_31,
@@ -1508,6 +1509,7 @@ class Order(ModelObjectType):
 
     @classmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     # TODO: We should optimize it in/after PR#5819
     def resolve_shipping_methods(cls, root: models.Order, info):
         def with_channel(channel):
@@ -1526,6 +1528,7 @@ class Order(ModelObjectType):
 
     @classmethod
     @traced_resolver
+    @prevent_sync_event_circular_query
     # TODO: We should optimize it in/after PR#5819
     def resolve_available_shipping_methods(cls, root: models.Order, info):
         return cls.resolve_shipping_methods(root, info).then(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -23656,6 +23656,273 @@ type WarehouseDeleted implements Event {
   warehouse: Warehouse
 }
 
+"""
+Authorize payment.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentAuthorize implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """Look up a payment."""
+  payment: Payment
+}
+
+"""
+Capture payment.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentCaptureEvent implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """Look up a payment."""
+  payment: Payment
+}
+
+"""
+Refund payment.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentRefundEvent implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """Look up a payment."""
+  payment: Payment
+}
+
+"""
+Void payment.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentVoidEvent implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """Look up a payment."""
+  payment: Payment
+}
+
+"""
+Confirm payment.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentConfirmEvent implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """Look up a payment."""
+  payment: Payment
+}
+
+"""
+Process payment.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentProcessEvent implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """Look up a payment."""
+  payment: Payment
+}
+
+"""
+List payment gateways.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type PaymentListGateways implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The checkout the event relates to."""
+  checkout: Checkout
+}
+
+"""
+Filter shipping methods for order.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type OrderFilterShippingMethods implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The order the event relates to."""
+  order: Order
+
+  """
+  Shipping methods that can be used with this checkout.
+  
+  Added in Saleor 3.6.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  shippingMethods: [ShippingMethod!]
+}
+
+"""
+Filter shipping methods for checkout.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type CheckoutFilterShippingMethods implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The checkout the event relates to."""
+  checkout: Checkout
+
+  """
+  Shipping methods that can be used with this checkout.
+  
+  Added in Saleor 3.6.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  shippingMethods: [ShippingMethod!]
+}
+
+"""
+List shipping methods for checkout.
+
+Added in Saleor 3.6.
+
+Note: this API is currently in Feature Preview and can be subject to changes at later point.
+"""
+type ShippingListMethodsForCheckout implements Event {
+  """Time of the event."""
+  issuedAt: DateTime
+
+  """Saleor version that triggered the event."""
+  version: String
+
+  """The user or application that triggered the event."""
+  issuingPrincipal: IssuingPrincipal
+
+  """The application receiving the webhook."""
+  recipient: App
+
+  """The checkout the event relates to."""
+  checkout: Checkout
+
+  """
+  Shipping methods that can be used with this checkout.
+  
+  Added in Saleor 3.6.
+  
+  Note: this API is currently in Feature Preview and can be subject to changes at later point.
+  """
+  shippingMethods: [ShippingMethod!]
+}
+
 """_Any value scalar as defined by Federation spec."""
 scalar _Any
 

--- a/saleor/graphql/tests/queries/fragments.py
+++ b/saleor/graphql/tests/queries/fragments.py
@@ -414,3 +414,15 @@ fragment AttributeValueDetails on AttributeValue {
   value
 }
 """
+
+PAYMENT_DETAILS = """
+fragment PaymentDetails on Payment {
+  id
+  total {
+    amount
+    currency
+  }
+  isActive
+  gateway
+}
+"""

--- a/saleor/graphql/webhook/subscription_payload.py
+++ b/saleor/graphql/webhook/subscription_payload.py
@@ -58,6 +58,8 @@ def check_document_is_single_subscription(document: GraphQLDocument) -> bool:
     """
     subscriptions = []
     for definition in document.document_ast.definitions:
+        if len(definition.selection_set.selections) != 1:
+            return False
         if isinstance(definition, FragmentDefinition):
             pass
         elif isinstance(definition, OperationDefinition):
@@ -70,7 +72,7 @@ def check_document_is_single_subscription(document: GraphQLDocument) -> bool:
     return len(subscriptions) == 1
 
 
-def initialize_request(requestor=None) -> HttpRequest:
+def initialize_request(requestor=None, sync_event=False) -> HttpRequest:
     """Prepare a request object for webhook subscription.
 
     It creates a dummy request object.
@@ -92,6 +94,7 @@ def initialize_request(requestor=None) -> HttpRequest:
         request.META["HTTP_X_FORWARDED_PROTO"] = "https"
         request.META["SERVER_PORT"] = "443"
 
+    request.sync_event = sync_event  # type: ignore
     request.requestor = requestor  # type: ignore
     request.request_time = request_time  # type: ignore
     request.site = SimpleLazyObject(lambda: Site.objects.get_current())  # type: ignore

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -11,6 +11,7 @@ from ...core.notify_events import NotifyEventType
 from ...core.taxes import TaxData, TaxType
 from ...core.utils.json_serializer import CustomJsonEncoder
 from ...payment import PaymentError, TransactionKind
+from ...payment.models import Payment
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from ...webhook.payloads import (
     generate_checkout_payload,
@@ -1162,7 +1163,14 @@ class WebhookPlugin(BasePlugin):
             )
 
         webhook_payload = generate_payment_payload(payment_information)
-        response_data = trigger_webhook_sync(event_type, webhook_payload, app)
+        payment = Payment.objects.filter(id=payment_information.payment_id).first()
+        if not payment:
+            raise PaymentError(
+                f"Payment with id: {payment_information.payment_id} not found."
+            )
+        response_data = trigger_webhook_sync(
+            event_type, webhook_payload, app, subscribable_object=payment
+        )
         if response_data is None:
             raise PaymentError(
                 f"Payment method {payment_information.gateway} is not available: "
@@ -1192,6 +1200,7 @@ class WebhookPlugin(BasePlugin):
                 event_type=WebhookEventSyncType.PAYMENT_LIST_GATEWAYS,
                 data=generate_list_gateways_payload(currency, checkout),
                 app=app,
+                subscribable_object=checkout,
             )
             if response_data:
                 app_gateways = parse_list_payment_gateways_response(response_data, app)
@@ -1297,12 +1306,14 @@ class WebhookPlugin(BasePlugin):
             WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT
         ).prefetch_related("webhooks")
         if apps:
+            # consider lazy loading
             payload = generate_checkout_payload(checkout, self.requestor)
             for app in apps:
                 response_data = trigger_webhook_sync(
                     event_type=WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
                     data=payload,
                     app=app,
+                    subscribable_object=checkout,
                 )
                 if response_data:
                     shipping_methods = parse_list_shipping_methods_response(
@@ -1356,6 +1367,7 @@ class WebhookPlugin(BasePlugin):
             previous_value=previous_value,
             payload_fun=payload_fun,
             cache_key=cache_key,
+            subscribable_object=order,
         )
 
     def excluded_shipping_methods_for_checkout(
@@ -1375,6 +1387,7 @@ class WebhookPlugin(BasePlugin):
             previous_value=previous_value,
             payload_fun=payload_function,
             cache_key=cache_key,
+            subscribable_object=checkout,
         )
 
     def is_event_active(self, event: str, channel=Optional[str]):

--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -27,7 +27,11 @@ from ...graphql.webhook.subscription_payload import (
 from ...payment import PaymentError
 from ...site.models import Site
 from ...webhook import observability
-from ...webhook.event_types import SUBSCRIBABLE_EVENTS, WebhookEventAsyncType
+from ...webhook.event_types import (
+    SUBSCRIBABLE_EVENTS,
+    WebhookEventAsyncType,
+    WebhookEventSyncType,
+)
 from ...webhook.observability import WebhookData
 from ...webhook.utils import get_webhooks_for_event
 from . import signature_for_payload
@@ -67,9 +71,9 @@ class WebhookResponse:
 def create_deliveries_for_subscriptions(
     event_type, subscribable_object, webhooks, requestor=None
 ) -> List[EventDelivery]:
-    """Create webhook payload based on subscription query.
+    """Create a list of event deliveries with payloads based on subscription query.
 
-    It uses a defined subscription query, defined for webhook to explicitly determine
+    It uses a subscription query, defined for webhook to explicitly determine
     what fields should be included in the payload.
 
     :param event_type: event type which should be triggered.
@@ -90,7 +94,9 @@ def create_deliveries_for_subscriptions(
             event_type=event_type,
             subscribable_object=subscribable_object,
             subscription_query=webhook.subscription_query,
-            request=initialize_request(requestor),
+            request=initialize_request(
+                requestor, event_type in WebhookEventSyncType.ALL
+            ),
             app=webhook.app,
         )
         if not data:
@@ -112,6 +118,50 @@ def create_deliveries_for_subscriptions(
 
     EventPayload.objects.bulk_create(event_payloads)
     return EventDelivery.objects.bulk_create(event_deliveries)
+
+
+def create_delivery_for_subscription_sync_event(
+    event_type, subscribable_object, webhook, requestor=None
+) -> Optional[EventDelivery]:
+    """Generate webhook payload based on subscription query and create delivery object.
+
+    It uses a defined subscription query, defined for webhook to explicitly determine
+    what fields should be included in the payload.
+
+    :param event_type: event type which should be triggered.
+    :param subscribable_object: subscribable object to process via subscription query.
+    :param webhook: webhook object for which delivery will be created.
+    :param requestor: used in subscription webhooks to generate meta data for payload.
+    :return: List of event deliveries to send via webhook tasks.
+    """
+    if event_type not in SUBSCRIBABLE_EVENTS:
+        logger.info(
+            "Skipping subscription webhook. Event %s is not subscribable.", event_type
+        )
+        return None
+
+    data = generate_payload_from_subscription(
+        event_type=event_type,
+        subscribable_object=subscribable_object,
+        subscription_query=webhook.subscription_query,
+        request=initialize_request(requestor, event_type in WebhookEventSyncType.ALL),
+        app=webhook.app,
+    )
+    if not data:
+        # PaymentError is a temporary exception type. New type will be implemented
+        # in separate PR to ensure proper handling for all sync events.
+        # It was implemented when sync webhooks were handling payment events only.
+        raise PaymentError(
+            "No payload was generated with subscription for event: %s" % event_type
+        )
+    event_payload = EventPayload.objects.create(payload=json.dumps({**data}))
+    event_delivery = EventDelivery.objects.create(
+        status=EventDeliveryStatus.PENDING,
+        event_type=event_type,
+        payload=event_payload,
+        webhook=webhook,
+    )
+    return event_delivery
 
 
 def trigger_webhooks_async(
@@ -159,20 +209,34 @@ def group_webhooks_by_subscription(webhooks):
 
 
 def trigger_webhook_sync(
-    event_type: str, data: str, app: "App", timeout=None
+    event_type: str,
+    data: str,
+    app: "App",
+    subscribable_object=None,
+    timeout=None,
 ) -> Optional[Dict[Any, Any]]:
     """Send a synchronous webhook request."""
     webhooks = get_webhooks_for_event(event_type, app.webhooks.all())
     webhook = webhooks.first()
     if not webhook:
         raise PaymentError(f"No payment webhook found for event: {event_type}.")
-    event_payload = EventPayload.objects.create(payload=data)
-    delivery = EventDelivery.objects.create(
-        status=EventDeliveryStatus.PENDING,
-        event_type=event_type,
-        payload=event_payload,
-        webhook=webhook,
-    )
+    if webhook.subscription_query:
+        delivery = create_delivery_for_subscription_sync_event(
+            event_type=event_type,
+            subscribable_object=subscribable_object,
+            webhook=webhook,
+        )
+        if not delivery:
+            return None
+
+    else:
+        event_payload = EventPayload.objects.create(payload=data)
+        delivery = EventDelivery.objects.create(
+            status=EventDeliveryStatus.PENDING,
+            event_type=event_type,
+            payload=event_payload,
+            webhook=webhook,
+        )
     kwargs = {}
     if timeout:
         kwargs = {"timeout": timeout}

--- a/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/fixtures.py
@@ -1,8 +1,8 @@
 import pytest
 
-from .....webhook.event_types import WebhookEventAsyncType
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .....webhook.models import Webhook
-from . import subscription_queries
+from . import subscription_queries as queries
 
 
 @pytest.fixture
@@ -23,49 +23,45 @@ def subscription_webhook(webhook_app):
 @pytest.fixture
 def subscription_address_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ADDRESS_CREATED, WebhookEventAsyncType.ADDRESS_CREATED
+        queries.ADDRESS_CREATED, WebhookEventAsyncType.ADDRESS_CREATED
     )
 
 
 @pytest.fixture
 def subscription_address_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ADDRESS_UPDATED, WebhookEventAsyncType.ADDRESS_UPDATED
+        queries.ADDRESS_UPDATED, WebhookEventAsyncType.ADDRESS_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_address_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ADDRESS_DELETED, WebhookEventAsyncType.ADDRESS_DELETED
+        queries.ADDRESS_DELETED, WebhookEventAsyncType.ADDRESS_DELETED
     )
 
 
 @pytest.fixture
 def subscription_app_installed_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.APP_INSTALLED, WebhookEventAsyncType.APP_INSTALLED
+        queries.APP_INSTALLED, WebhookEventAsyncType.APP_INSTALLED
     )
 
 
 @pytest.fixture
 def subscription_app_updated_webhook(subscription_webhook):
-    return subscription_webhook(
-        subscription_queries.APP_UPDATED, WebhookEventAsyncType.APP_UPDATED
-    )
+    return subscription_webhook(queries.APP_UPDATED, WebhookEventAsyncType.APP_UPDATED)
 
 
 @pytest.fixture
 def subscription_app_deleted_webhook(subscription_webhook):
-    return subscription_webhook(
-        subscription_queries.APP_DELETED, WebhookEventAsyncType.APP_DELETED
-    )
+    return subscription_webhook(queries.APP_DELETED, WebhookEventAsyncType.APP_DELETED)
 
 
 @pytest.fixture
 def subscription_app_status_changed_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.APP_STATUS_CHANGED,
+        queries.APP_STATUS_CHANGED,
         WebhookEventAsyncType.APP_STATUS_CHANGED,
     )
 
@@ -73,28 +69,28 @@ def subscription_app_status_changed_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_attribute_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ATTRIBUTE_CREATED, WebhookEventAsyncType.ATTRIBUTE_CREATED
+        queries.ATTRIBUTE_CREATED, WebhookEventAsyncType.ATTRIBUTE_CREATED
     )
 
 
 @pytest.fixture
 def subscription_attribute_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ATTRIBUTE_UPDATED, WebhookEventAsyncType.ATTRIBUTE_UPDATED
+        queries.ATTRIBUTE_UPDATED, WebhookEventAsyncType.ATTRIBUTE_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_attribute_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ATTRIBUTE_DELETED, WebhookEventAsyncType.ATTRIBUTE_DELETED
+        queries.ATTRIBUTE_DELETED, WebhookEventAsyncType.ATTRIBUTE_DELETED
     )
 
 
 @pytest.fixture
 def subscription_attribute_value_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ATTRIBUTE_VALUE_CREATED,
+        queries.ATTRIBUTE_VALUE_CREATED,
         WebhookEventAsyncType.ATTRIBUTE_VALUE_CREATED,
     )
 
@@ -102,7 +98,7 @@ def subscription_attribute_value_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_attribute_value_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ATTRIBUTE_VALUE_UPDATED,
+        queries.ATTRIBUTE_VALUE_UPDATED,
         WebhookEventAsyncType.ATTRIBUTE_VALUE_UPDATED,
     )
 
@@ -110,7 +106,7 @@ def subscription_attribute_value_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_attribute_value_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ATTRIBUTE_VALUE_DELETED,
+        queries.ATTRIBUTE_VALUE_DELETED,
         WebhookEventAsyncType.ATTRIBUTE_VALUE_DELETED,
     )
 
@@ -118,49 +114,49 @@ def subscription_attribute_value_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_category_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CATEGORY_CREATED, WebhookEventAsyncType.CATEGORY_CREATED
+        queries.CATEGORY_CREATED, WebhookEventAsyncType.CATEGORY_CREATED
     )
 
 
 @pytest.fixture
 def subscription_category_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CATEGORY_UPDATED, WebhookEventAsyncType.CATEGORY_UPDATED
+        queries.CATEGORY_UPDATED, WebhookEventAsyncType.CATEGORY_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_category_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CATEGORY_DELETED, WebhookEventAsyncType.CATEGORY_DELETED
+        queries.CATEGORY_DELETED, WebhookEventAsyncType.CATEGORY_DELETED
     )
 
 
 @pytest.fixture
 def subscription_channel_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CHANNEL_CREATED, WebhookEventAsyncType.CHANNEL_CREATED
+        queries.CHANNEL_CREATED, WebhookEventAsyncType.CHANNEL_CREATED
     )
 
 
 @pytest.fixture
 def subscription_channel_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CHANNEL_UPDATED, WebhookEventAsyncType.CHANNEL_UPDATED
+        queries.CHANNEL_UPDATED, WebhookEventAsyncType.CHANNEL_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_channel_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CHANNEL_DELETED, WebhookEventAsyncType.CHANNEL_DELETED
+        queries.CHANNEL_DELETED, WebhookEventAsyncType.CHANNEL_DELETED
     )
 
 
 @pytest.fixture
 def subscription_channel_status_changed_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CHANNEL_STATUS_CHANGED,
+        queries.CHANNEL_STATUS_CHANGED,
         WebhookEventAsyncType.CHANNEL_STATUS_CHANGED,
     )
 
@@ -168,28 +164,28 @@ def subscription_channel_status_changed_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_gift_card_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.GIFT_CARD_CREATED, WebhookEventAsyncType.GIFT_CARD_CREATED
+        queries.GIFT_CARD_CREATED, WebhookEventAsyncType.GIFT_CARD_CREATED
     )
 
 
 @pytest.fixture
 def subscription_gift_card_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.GIFT_CARD_UPDATED, WebhookEventAsyncType.GIFT_CARD_UPDATED
+        queries.GIFT_CARD_UPDATED, WebhookEventAsyncType.GIFT_CARD_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_gift_card_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.GIFT_CARD_DELETED, WebhookEventAsyncType.GIFT_CARD_DELETED
+        queries.GIFT_CARD_DELETED, WebhookEventAsyncType.GIFT_CARD_DELETED
     )
 
 
 @pytest.fixture
 def subscription_gift_card_status_changed_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.GIFT_CARD_STATUS_CHANGED,
+        queries.GIFT_CARD_STATUS_CHANGED,
         WebhookEventAsyncType.GIFT_CARD_STATUS_CHANGED,
     )
 
@@ -197,49 +193,49 @@ def subscription_gift_card_status_changed_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_menu_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.MENU_CREATED, WebhookEventAsyncType.MENU_CREATED
+        queries.MENU_CREATED, WebhookEventAsyncType.MENU_CREATED
     )
 
 
 @pytest.fixture
 def subscription_menu_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.MENU_UPDATED, WebhookEventAsyncType.MENU_UPDATED
+        queries.MENU_UPDATED, WebhookEventAsyncType.MENU_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_menu_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.MENU_DELETED, WebhookEventAsyncType.MENU_DELETED
+        queries.MENU_DELETED, WebhookEventAsyncType.MENU_DELETED
     )
 
 
 @pytest.fixture
 def subscription_menu_item_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.MENU_ITEM_CREATED, WebhookEventAsyncType.MENU_ITEM_CREATED
+        queries.MENU_ITEM_CREATED, WebhookEventAsyncType.MENU_ITEM_CREATED
     )
 
 
 @pytest.fixture
 def subscription_menu_item_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.MENU_ITEM_UPDATED, WebhookEventAsyncType.MENU_ITEM_UPDATED
+        queries.MENU_ITEM_UPDATED, WebhookEventAsyncType.MENU_ITEM_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_menu_item_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.MENU_ITEM_DELETED, WebhookEventAsyncType.MENU_ITEM_DELETED
+        queries.MENU_ITEM_DELETED, WebhookEventAsyncType.MENU_ITEM_DELETED
     )
 
 
 @pytest.fixture
 def subscription_shipping_price_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SHIPPING_PRICE_CREATED,
+        queries.SHIPPING_PRICE_CREATED,
         WebhookEventAsyncType.SHIPPING_PRICE_CREATED,
     )
 
@@ -247,7 +243,7 @@ def subscription_shipping_price_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_shipping_price_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SHIPPING_PRICE_UPDATED_UPDATED,
+        queries.SHIPPING_PRICE_UPDATED_UPDATED,
         WebhookEventAsyncType.SHIPPING_PRICE_UPDATED,
     )
 
@@ -255,7 +251,7 @@ def subscription_shipping_price_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_shipping_price_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SHIPPING_PRICE_DELETED,
+        queries.SHIPPING_PRICE_DELETED,
         WebhookEventAsyncType.SHIPPING_PRICE_DELETED,
     )
 
@@ -263,7 +259,7 @@ def subscription_shipping_price_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_shipping_zone_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SHIPPING_ZONE_CREATED,
+        queries.SHIPPING_ZONE_CREATED,
         WebhookEventAsyncType.SHIPPING_ZONE_CREATED,
     )
 
@@ -271,7 +267,7 @@ def subscription_shipping_zone_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_shipping_zone_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SHIPPING_ZONE_UPDATED_UPDATED,
+        queries.SHIPPING_ZONE_UPDATED_UPDATED,
         WebhookEventAsyncType.SHIPPING_ZONE_UPDATED,
     )
 
@@ -279,7 +275,7 @@ def subscription_shipping_zone_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_shipping_zone_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SHIPPING_ZONE_DELETED,
+        queries.SHIPPING_ZONE_DELETED,
         WebhookEventAsyncType.SHIPPING_ZONE_DELETED,
     )
 
@@ -287,28 +283,28 @@ def subscription_shipping_zone_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_product_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PRODUCT_UPDATED, WebhookEventAsyncType.PRODUCT_UPDATED
+        queries.PRODUCT_UPDATED, WebhookEventAsyncType.PRODUCT_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_product_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PRODUCT_CREATED, WebhookEventAsyncType.PRODUCT_CREATED
+        queries.PRODUCT_CREATED, WebhookEventAsyncType.PRODUCT_CREATED
     )
 
 
 @pytest.fixture
 def subscription_product_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PRODUCT_DELETED, WebhookEventAsyncType.PRODUCT_DELETED
+        queries.PRODUCT_DELETED, WebhookEventAsyncType.PRODUCT_DELETED
     )
 
 
 @pytest.fixture
 def subscription_product_variant_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PRODUCT_VARIANT_CREATED,
+        queries.PRODUCT_VARIANT_CREATED,
         WebhookEventAsyncType.PRODUCT_VARIANT_CREATED,
     )
 
@@ -316,7 +312,7 @@ def subscription_product_variant_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_product_variant_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PRODUCT_VARIANT_UPDATED,
+        queries.PRODUCT_VARIANT_UPDATED,
         WebhookEventAsyncType.PRODUCT_VARIANT_UPDATED,
     )
 
@@ -324,7 +320,7 @@ def subscription_product_variant_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_product_variant_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PRODUCT_VARIANT_DELETED,
+        queries.PRODUCT_VARIANT_DELETED,
         WebhookEventAsyncType.PRODUCT_VARIANT_DELETED,
     )
 
@@ -332,7 +328,7 @@ def subscription_product_variant_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_product_variant_out_of_stock_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PRODUCT_VARIANT_OUT_OF_STOCK,
+        queries.PRODUCT_VARIANT_OUT_OF_STOCK,
         WebhookEventAsyncType.PRODUCT_VARIANT_OUT_OF_STOCK,
     )
 
@@ -340,7 +336,7 @@ def subscription_product_variant_out_of_stock_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_product_variant_back_in_stock_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PRODUCT_VARIANT_BACK_IN_STOCK,
+        queries.PRODUCT_VARIANT_BACK_IN_STOCK,
         WebhookEventAsyncType.PRODUCT_VARIANT_BACK_IN_STOCK,
     )
 
@@ -348,49 +344,49 @@ def subscription_product_variant_back_in_stock_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_order_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ORDER_CREATED, WebhookEventAsyncType.ORDER_CREATED
+        queries.ORDER_CREATED, WebhookEventAsyncType.ORDER_CREATED
     )
 
 
 @pytest.fixture
 def subscription_order_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ORDER_UPDATED, WebhookEventAsyncType.ORDER_UPDATED
+        queries.ORDER_UPDATED, WebhookEventAsyncType.ORDER_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_order_confirmed_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ORDER_CONFIRMED, WebhookEventAsyncType.ORDER_CONFIRMED
+        queries.ORDER_CONFIRMED, WebhookEventAsyncType.ORDER_CONFIRMED
     )
 
 
 @pytest.fixture
 def subscription_order_fully_paid_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ORDER_FULLY_PAID, WebhookEventAsyncType.ORDER_FULLY_PAID
+        queries.ORDER_FULLY_PAID, WebhookEventAsyncType.ORDER_FULLY_PAID
     )
 
 
 @pytest.fixture
 def subscription_order_cancelled_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ORDER_CANCELLED, WebhookEventAsyncType.ORDER_CANCELLED
+        queries.ORDER_CANCELLED, WebhookEventAsyncType.ORDER_CANCELLED
     )
 
 
 @pytest.fixture
 def subscription_order_fulfilled_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.ORDER_FULFILLED, WebhookEventAsyncType.ORDER_FULFILLED
+        queries.ORDER_FULFILLED, WebhookEventAsyncType.ORDER_FULFILLED
     )
 
 
 @pytest.fixture
 def subscription_draft_order_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.DRAFT_ORDER_CREATED,
+        queries.DRAFT_ORDER_CREATED,
         WebhookEventAsyncType.DRAFT_ORDER_CREATED,
     )
 
@@ -398,7 +394,7 @@ def subscription_draft_order_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_draft_order_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.DRAFT_ORDER_UPDATED,
+        queries.DRAFT_ORDER_UPDATED,
         WebhookEventAsyncType.DRAFT_ORDER_UPDATED,
     )
 
@@ -406,7 +402,7 @@ def subscription_draft_order_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_draft_order_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.DRAFT_ORDER_DELETED,
+        queries.DRAFT_ORDER_DELETED,
         WebhookEventAsyncType.DRAFT_ORDER_DELETED,
     )
 
@@ -414,56 +410,54 @@ def subscription_draft_order_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_sale_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SALE_CREATED, WebhookEventAsyncType.SALE_CREATED
+        queries.SALE_CREATED, WebhookEventAsyncType.SALE_CREATED
     )
 
 
 @pytest.fixture
 def subscription_sale_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SALE_UPDATED, WebhookEventAsyncType.SALE_UPDATED
+        queries.SALE_UPDATED, WebhookEventAsyncType.SALE_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_sale_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.SALE_DELETED, WebhookEventAsyncType.SALE_DELETED
+        queries.SALE_DELETED, WebhookEventAsyncType.SALE_DELETED
     )
 
 
 @pytest.fixture
 def subscription_sale_toggle_webhook(subscription_webhook):
-    return subscription_webhook(
-        subscription_queries.SALE_TOGGLE, WebhookEventAsyncType.SALE_TOGGLE
-    )
+    return subscription_webhook(queries.SALE_TOGGLE, WebhookEventAsyncType.SALE_TOGGLE)
 
 
 @pytest.fixture
 def subscription_invoice_requested_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.INVOICE_REQUESTED, WebhookEventAsyncType.INVOICE_REQUESTED
+        queries.INVOICE_REQUESTED, WebhookEventAsyncType.INVOICE_REQUESTED
     )
 
 
 @pytest.fixture
 def subscription_invoice_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.INVOICE_DELETED, WebhookEventAsyncType.INVOICE_DELETED
+        queries.INVOICE_DELETED, WebhookEventAsyncType.INVOICE_DELETED
     )
 
 
 @pytest.fixture
 def subscription_invoice_sent_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.INVOICE_SENT, WebhookEventAsyncType.INVOICE_SENT
+        queries.INVOICE_SENT, WebhookEventAsyncType.INVOICE_SENT
     )
 
 
 @pytest.fixture
 def subscription_fulfillment_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.FULFILLMENT_CREATED,
+        queries.FULFILLMENT_CREATED,
         WebhookEventAsyncType.FULFILLMENT_CREATED,
     )
 
@@ -471,7 +465,7 @@ def subscription_fulfillment_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_fulfillment_canceled_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.FULFILLMENT_CANCELED,
+        queries.FULFILLMENT_CANCELED,
         WebhookEventAsyncType.FULFILLMENT_CANCELED,
     )
 
@@ -479,28 +473,28 @@ def subscription_fulfillment_canceled_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_customer_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CUSTOMER_CREATED, WebhookEventAsyncType.CUSTOMER_CREATED
+        queries.CUSTOMER_CREATED, WebhookEventAsyncType.CUSTOMER_CREATED
     )
 
 
 @pytest.fixture
 def subscription_customer_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CUSTOMER_UPDATED, WebhookEventAsyncType.CUSTOMER_UPDATED
+        queries.CUSTOMER_UPDATED, WebhookEventAsyncType.CUSTOMER_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_customer_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CUSTOMER_DELETED, WebhookEventAsyncType.CUSTOMER_DELETED
+        queries.CUSTOMER_DELETED, WebhookEventAsyncType.CUSTOMER_DELETED
     )
 
 
 @pytest.fixture
 def subscription_collection_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.COLLECTION_CREATED,
+        queries.COLLECTION_CREATED,
         WebhookEventAsyncType.COLLECTION_CREATED,
     )
 
@@ -508,7 +502,7 @@ def subscription_collection_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_collection_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.COLLECTION_UPDATED,
+        queries.COLLECTION_UPDATED,
         WebhookEventAsyncType.COLLECTION_UPDATED,
     )
 
@@ -516,7 +510,7 @@ def subscription_collection_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_collection_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.COLLECTION_DELETED,
+        queries.COLLECTION_DELETED,
         WebhookEventAsyncType.COLLECTION_DELETED,
     )
 
@@ -524,28 +518,28 @@ def subscription_collection_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_checkout_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CHECKOUT_CREATED, WebhookEventAsyncType.CHECKOUT_CREATED
+        queries.CHECKOUT_CREATED, WebhookEventAsyncType.CHECKOUT_CREATED
     )
 
 
 @pytest.fixture
 def subscription_checkout_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.CHECKOUT_UPDATED, WebhookEventAsyncType.CHECKOUT_UPDATED
+        queries.CHECKOUT_UPDATED, WebhookEventAsyncType.CHECKOUT_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_page_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PAGE_CREATED, WebhookEventAsyncType.PAGE_CREATED
+        queries.PAGE_CREATED, WebhookEventAsyncType.PAGE_CREATED
     )
 
 
 @pytest.fixture
 def subscription_page_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PAGE_UPDATED,
+        queries.PAGE_UPDATED,
         WebhookEventAsyncType.PAGE_UPDATED,
     )
 
@@ -553,7 +547,7 @@ def subscription_page_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_page_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PAGE_DELETED,
+        queries.PAGE_DELETED,
         WebhookEventAsyncType.PAGE_DELETED,
     )
 
@@ -561,28 +555,28 @@ def subscription_page_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_page_type_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PAGE_TYPE_CREATED, WebhookEventAsyncType.PAGE_TYPE_CREATED
+        queries.PAGE_TYPE_CREATED, WebhookEventAsyncType.PAGE_TYPE_CREATED
     )
 
 
 @pytest.fixture
 def subscription_page_type_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PAGE_TYPE_UPDATED, WebhookEventAsyncType.PAGE_TYPE_UPDATED
+        queries.PAGE_TYPE_UPDATED, WebhookEventAsyncType.PAGE_TYPE_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_page_type_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PAGE_TYPE_DELETED, WebhookEventAsyncType.PAGE_TYPE_DELETED
+        queries.PAGE_TYPE_DELETED, WebhookEventAsyncType.PAGE_TYPE_DELETED
     )
 
 
 @pytest.fixture
 def subscription_permission_group_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PERMISSION_GROUP_CREATED,
+        queries.PERMISSION_GROUP_CREATED,
         WebhookEventAsyncType.PERMISSION_GROUP_CREATED,
     )
 
@@ -590,7 +584,7 @@ def subscription_permission_group_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_permission_group_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PERMISSION_GROUP_UPDATED,
+        queries.PERMISSION_GROUP_UPDATED,
         WebhookEventAsyncType.PERMISSION_GROUP_UPDATED,
     )
 
@@ -598,7 +592,7 @@ def subscription_permission_group_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_permission_group_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.PERMISSION_GROUP_DELETED,
+        queries.PERMISSION_GROUP_DELETED,
         WebhookEventAsyncType.PERMISSION_GROUP_DELETED,
     )
 
@@ -606,7 +600,7 @@ def subscription_permission_group_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_product_created_multiple_events_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.MULTIPLE_EVENTS,
+        queries.MULTIPLE_EVENTS,
         WebhookEventAsyncType.TRANSLATION_CREATED,
     )
 
@@ -614,14 +608,14 @@ def subscription_product_created_multiple_events_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_staff_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.STAFF_CREATED, WebhookEventAsyncType.STAFF_CREATED
+        queries.STAFF_CREATED, WebhookEventAsyncType.STAFF_CREATED
     )
 
 
 @pytest.fixture
 def subscription_staff_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.STAFF_UPDATED,
+        queries.STAFF_UPDATED,
         WebhookEventAsyncType.STAFF_UPDATED,
     )
 
@@ -629,7 +623,7 @@ def subscription_staff_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_staff_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.STAFF_DELETED,
+        queries.STAFF_DELETED,
         WebhookEventAsyncType.STAFF_DELETED,
     )
 
@@ -637,7 +631,7 @@ def subscription_staff_deleted_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_translation_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.TRANSLATION_CREATED,
+        queries.TRANSLATION_CREATED,
         WebhookEventAsyncType.TRANSLATION_CREATED,
     )
 
@@ -645,7 +639,7 @@ def subscription_translation_created_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_translation_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.TRANSLATION_UPDATED,
+        queries.TRANSLATION_UPDATED,
         WebhookEventAsyncType.TRANSLATION_UPDATED,
     )
 
@@ -653,48 +647,171 @@ def subscription_translation_updated_webhook(subscription_webhook):
 @pytest.fixture
 def subscription_warehouse_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.WAREHOUSE_CREATED, WebhookEventAsyncType.WAREHOUSE_CREATED
+        queries.WAREHOUSE_CREATED, WebhookEventAsyncType.WAREHOUSE_CREATED
     )
 
 
 @pytest.fixture
 def subscription_warehouse_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.WAREHOUSE_UPDATED, WebhookEventAsyncType.WAREHOUSE_UPDATED
+        queries.WAREHOUSE_UPDATED, WebhookEventAsyncType.WAREHOUSE_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_warehouse_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.WAREHOUSE_DELETED, WebhookEventAsyncType.WAREHOUSE_DELETED
+        queries.WAREHOUSE_DELETED, WebhookEventAsyncType.WAREHOUSE_DELETED
     )
 
 
 @pytest.fixture
 def subscription_voucher_created_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.VOUCHER_CREATED, WebhookEventAsyncType.VOUCHER_CREATED
+        queries.VOUCHER_CREATED, WebhookEventAsyncType.VOUCHER_CREATED
     )
 
 
 @pytest.fixture
 def subscription_voucher_updated_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.VOUCHER_UPDATED, WebhookEventAsyncType.VOUCHER_UPDATED
+        queries.VOUCHER_UPDATED, WebhookEventAsyncType.VOUCHER_UPDATED
     )
 
 
 @pytest.fixture
 def subscription_voucher_deleted_webhook(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.VOUCHER_DELETED, WebhookEventAsyncType.VOUCHER_DELETED
+        queries.VOUCHER_DELETED, WebhookEventAsyncType.VOUCHER_DELETED
     )
 
 
 @pytest.fixture
 def subscription_voucher_webhook_with_meta(subscription_webhook):
     return subscription_webhook(
-        subscription_queries.VOUCHER_CREATED_WITH_META,
+        queries.VOUCHER_CREATED_WITH_META,
         WebhookEventAsyncType.VOUCHER_CREATED,
+    )
+
+
+@pytest.fixture
+def subscription_payment_authorize_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PAYMENT_AUTHORIZE, WebhookEventSyncType.PAYMENT_AUTHORIZE
+    )
+
+
+@pytest.fixture
+def subscription_payment_capture_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PAYMENT_CAPTURE, WebhookEventSyncType.PAYMENT_CAPTURE
+    )
+
+
+@pytest.fixture
+def subscription_payment_refund_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PAYMENT_REFUND, WebhookEventSyncType.PAYMENT_REFUND
+    )
+
+
+@pytest.fixture
+def subscription_payment_void_webhook(subscription_webhook):
+    return subscription_webhook(queries.PAYMENT_VOID, WebhookEventSyncType.PAYMENT_VOID)
+
+
+@pytest.fixture
+def subscription_payment_confirm_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PAYMENT_CONFIRM, WebhookEventSyncType.PAYMENT_CONFIRM
+    )
+
+
+@pytest.fixture
+def subscription_payment_process_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PAYMENT_PROCESS, WebhookEventSyncType.PAYMENT_PROCESS
+    )
+
+
+@pytest.fixture
+def subscription_payment_list_gateways_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.PAYMENT_LIST_GATEWAYS,
+        WebhookEventSyncType.PAYMENT_LIST_GATEWAYS,
+    )
+
+
+@pytest.fixture
+def subscription_checkout_filter_shipping_methods_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.CHECKOUT_FILTER_SHIPPING_METHODS,
+        WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
+    )
+
+
+@pytest.fixture
+def subscription_shipping_list_methods_for_checkout_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+        WebhookEventSyncType.SHIPPING_LIST_METHODS_FOR_CHECKOUT,
+    )
+
+
+@pytest.fixture
+def subscription_order_filter_shipping_methods_webhook(subscription_webhook):
+    return subscription_webhook(
+        queries.ORDER_FILTER_SHIPPING_METHODS,
+        WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+
+@pytest.fixture
+def subscription_checkout_filter_shipping_method_webhook_with_shipping_methods(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        queries.CHECKOUT_FILTER_SHIPPING_METHODS_CIRCULAR_SHIPPING_METHODS,
+        WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
+    )
+
+
+@pytest.fixture
+def subscription_checkout_filter_shipping_method_webhook_with_available_ship_methods(
+    subscription_webhook,
+):
+
+    return subscription_webhook(
+        queries.CHECKOUT_FILTER_SHIPPING_METHODS_AVAILABLE_SHIPPING_METHODS,
+        WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
+    )
+
+
+@pytest.fixture
+def subscription_checkout_filter_shipping_method_webhook_with_payment_gateways(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        queries.CHECKOUT_FILTER_SHIPPING_METHODS_AVAILABLE_PAYMENT_GATEWAYS,
+        WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
+    )
+
+
+@pytest.fixture
+def subscription_order_filter_shipping_methods_webhook_with_shipping_methods(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        queries.ORDER_FILTER_SHIPPING_METHODS_CIRCULAR_SHIPPING_METHODS,
+        WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
+    )
+
+
+@pytest.fixture
+def subscription_order_filter_shipping_methods_webhook_with_available_ship_methods(
+    subscription_webhook,
+):
+    return subscription_webhook(
+        queries.ORDER_FILTER_SHIPPING_METHODS_AVAILABLE_SHIPPING_METHODS,
+        WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
     )

--- a/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/payloads.py
@@ -440,3 +440,15 @@ def generate_warehouse_payload(warehouse, warehouse_global_id):
             }
         }
     )
+
+
+def generate_payment_payload(payment):
+    total = payment.get_total()
+    return {
+        "payment": {
+            "id": graphene.Node.to_global_id("Payment", payment.pk),
+            "total": {"amount": float(total.amount), "currency": total.currency},
+            "gateway": payment.gateway,
+            "isActive": payment.is_active,
+        }
+    }

--- a/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/subscription_queries.py
@@ -1552,3 +1552,236 @@ WAREHOUSE_DELETED = (
     }
 """
 )
+
+PAYMENT_AUTHORIZE = (
+    fragments.PAYMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PaymentAuthorize{
+          payment{
+            ...PaymentDetails
+          }
+        }
+      }
+    }
+    """
+)
+
+
+PAYMENT_CAPTURE = (
+    fragments.PAYMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PaymentCaptureEvent{
+          payment{
+            ...PaymentDetails
+          }
+        }
+      }
+    }
+    """
+)
+
+
+PAYMENT_REFUND = (
+    fragments.PAYMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PaymentRefundEvent{
+          payment{
+            ...PaymentDetails
+          }
+        }
+      }
+    }
+    """
+)
+
+
+PAYMENT_VOID = (
+    fragments.PAYMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PaymentVoidEvent{
+          payment{
+            ...PaymentDetails
+          }
+        }
+      }
+    }
+    """
+)
+
+
+PAYMENT_CONFIRM = (
+    fragments.PAYMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PaymentConfirmEvent{
+          payment{
+            ...PaymentDetails
+          }
+        }
+      }
+    }
+    """
+)
+
+
+PAYMENT_PROCESS = (
+    fragments.PAYMENT_DETAILS
+    + """
+    subscription{
+      event{
+        ...on PaymentProcessEvent{
+          payment{
+            ...PaymentDetails
+          }
+        }
+      }
+    }
+    """
+)
+
+PAYMENT_LIST_GATEWAYS = """
+    subscription{
+      event{
+        ...on PaymentListGateways{
+          checkout{
+            id
+          }
+        }
+      }
+    }
+    """
+
+ORDER_FILTER_SHIPPING_METHODS = """
+subscription{
+  event{
+    ...on OrderFilterShippingMethods{
+      order{
+        id
+      }
+      shippingMethods{
+      id
+      name
+      }
+    }
+  }
+}
+"""
+
+
+CHECKOUT_FILTER_SHIPPING_METHODS = """
+subscription{
+  event{
+    ...on CheckoutFilterShippingMethods{
+      checkout{
+        id
+      }
+      shippingMethods{
+        name
+        id
+      }
+    }
+  }
+}
+"""
+
+
+SHIPPING_LIST_METHODS_FOR_CHECKOUT = """
+subscription{
+  event{
+    ...on ShippingListMethodsForCheckout{
+      checkout{
+        id
+      }
+      shippingMethods{
+        name
+        id
+      }
+    }
+  }
+}
+"""
+
+
+CHECKOUT_FILTER_SHIPPING_METHODS_CIRCULAR_SHIPPING_METHODS = """
+subscription{
+  event{
+    ...on CheckoutFilterShippingMethods{
+      checkout{
+        id
+        shippingMethods{
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+CHECKOUT_FILTER_SHIPPING_METHODS_AVAILABLE_SHIPPING_METHODS = """
+subscription{
+  event{
+    ...on CheckoutFilterShippingMethods{
+      checkout{
+        id
+        availableShippingMethods{
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+CHECKOUT_FILTER_SHIPPING_METHODS_AVAILABLE_PAYMENT_GATEWAYS = """
+subscription{
+  event{
+    ...on CheckoutFilterShippingMethods{
+      checkout{
+        id
+        availablePaymentGateways{
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+ORDER_FILTER_SHIPPING_METHODS_AVAILABLE_SHIPPING_METHODS = """
+subscription{
+  event{
+    ...on OrderFilterShippingMethods{
+      order{
+        id
+        availableShippingMethods{
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+ORDER_FILTER_SHIPPING_METHODS_CIRCULAR_SHIPPING_METHODS = """
+subscription{
+  event{
+    ...on OrderFilterShippingMethods{
+      order{
+        id
+        shippingMethods{
+          id
+        }
+      }
+    }
+  }
+}
+"""

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscriptions_payments.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscriptions_payments.py
@@ -1,0 +1,115 @@
+import json
+
+import graphene
+
+from .....webhook.event_types import WebhookEventSyncType
+from ...tasks import create_deliveries_for_subscriptions
+from .payloads import generate_payment_payload
+
+
+def test_payment_authorize(payment, subscription_payment_authorize_webhook):
+    # given
+    webhooks = [subscription_payment_authorize_webhook]
+    event_type = WebhookEventSyncType.PAYMENT_AUTHORIZE
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, payment, webhooks)
+
+    # then
+    expected_payload = generate_payment_payload(payment)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_payment_capture(payment, subscription_payment_capture_webhook):
+    # given
+    webhooks = [subscription_payment_capture_webhook]
+    event_type = WebhookEventSyncType.PAYMENT_CAPTURE
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, payment, webhooks)
+
+    # then
+    expected_payload = generate_payment_payload(payment)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_payment_refund(payment, subscription_payment_refund_webhook):
+    # given
+    webhooks = [subscription_payment_refund_webhook]
+    event_type = WebhookEventSyncType.PAYMENT_REFUND
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, payment, webhooks)
+
+    # then
+    expected_payload = generate_payment_payload(payment)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_payment_void(payment, subscription_payment_void_webhook):
+    # given
+    webhooks = [subscription_payment_void_webhook]
+    event_type = WebhookEventSyncType.PAYMENT_VOID
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, payment, webhooks)
+
+    # then
+    expected_payload = generate_payment_payload(payment)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_payment_confirm(payment, subscription_payment_confirm_webhook):
+    # given
+    webhooks = [subscription_payment_confirm_webhook]
+    event_type = WebhookEventSyncType.PAYMENT_CONFIRM
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, payment, webhooks)
+
+    # then
+    expected_payload = generate_payment_payload(payment)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_payment_process(payment, subscription_payment_process_webhook):
+    # given
+    webhooks = [subscription_payment_process_webhook]
+    event_type = WebhookEventSyncType.PAYMENT_PROCESS
+
+    # when
+    deliveries = create_deliveries_for_subscriptions(event_type, payment, webhooks)
+
+    # then
+    expected_payload = generate_payment_payload(payment)
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]
+
+
+def test_payment_list_gateways(checkout, subscription_payment_list_gateways_webhook):
+    # given
+
+    webhooks = [subscription_payment_list_gateways_webhook]
+    event_type = WebhookEventSyncType.PAYMENT_LIST_GATEWAYS
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    # when
+
+    deliveries = create_deliveries_for_subscriptions(event_type, checkout, webhooks)
+
+    # then
+    expected_payload = {"checkout": {"id": checkout_id}}
+    assert json.loads(deliveries[0].payload.payload) == expected_payload
+    assert len(deliveries) == len(webhooks)
+    assert deliveries[0].webhook == webhooks[0]

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_webhook.py
@@ -1,9 +1,12 @@
 import dataclasses
+import json
 from unittest import mock
 
-from .....webhook.event_types import WebhookEventAsyncType
+from .....core.models import EventDelivery
+from .....webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
 from .....webhook.models import Webhook
-from ...tasks import trigger_webhooks_async
+from ...tasks import trigger_webhook_sync, trigger_webhooks_async
+from .payloads import generate_payment_payload
 
 TEST_ID = "test_id"
 
@@ -26,3 +29,22 @@ def test_trigger_webhooks_async_no_subscription_webhooks(
     data = {"regular_webhook": "data"}
     trigger_webhooks_async(data, webhook_type, webhooks, order)
     mocked_create_deliveries_for_subscriptions.assert_not_called()
+
+
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_trigger_webhook_sync_with_subscription(
+    mock_request, payment_app_with_subscription_webhooks, payment
+):
+    # given
+    payment_app = payment_app_with_subscription_webhooks
+    data = '{"key": "value"}'
+    expected_payment_payload = generate_payment_payload(payment)
+    # when
+    trigger_webhook_sync(
+        WebhookEventSyncType.PAYMENT_AUTHORIZE, data, payment_app, payment
+    )
+    event_delivery = EventDelivery.objects.first()
+
+    # then
+    assert json.loads(event_delivery.payload.payload) == expected_payment_payload
+    mock_request.assert_called_once_with(payment_app.name, event_delivery)

--- a/saleor/plugins/webhook/tests/test_payment_webhook.py
+++ b/saleor/plugins/webhook/tests/test_payment_webhook.py
@@ -55,6 +55,24 @@ def test_trigger_webhook_sync(mock_request, payment_app):
     mock_request.assert_called_once_with(payment_app.name, event_delivery)
 
 
+@mock.patch("saleor.plugins.webhook.tasks.create_delivery_for_subscription_sync_event")
+@mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
+def test_trigger_webhook_sync_with_subscription(
+    mock_request,
+    mock_delivery_create,
+    payment,
+    payment_app_with_subscription_webhooks,
+):
+    payment_app = payment_app_with_subscription_webhooks
+    data = '{"key": "value"}'
+    fake_delivery = "fake_delivery"
+    mock_delivery_create.return_value = fake_delivery
+    trigger_webhook_sync(
+        WebhookEventSyncType.PAYMENT_CAPTURE, data, payment_app, payment
+    )
+    mock_request.assert_called_once_with(payment_app.name, fake_delivery)
+
+
 @mock.patch("saleor.plugins.webhook.tasks.send_webhook_request_sync")
 def test_trigger_webhook_sync_use_first_webhook(mock_request, payment_app):
     webhook_1 = payment_app.webhooks.first()

--- a/saleor/plugins/webhook/tests/test_shipping_webhook.py
+++ b/saleor/plugins/webhook/tests/test_shipping_webhook.py
@@ -119,7 +119,8 @@ def test_excluded_shipping_methods_for_order(
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         payload,
         shipping_app,
-        EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
+        subscribable_object=order_with_lines,
+        timeout=EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
     )
     expected_cache_key = CACHE_EXCLUDED_SHIPPING_KEY + str(order_with_lines.id)
 
@@ -198,13 +199,15 @@ def test_multiple_app_with_excluded_shipping_methods_for_order(
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         payload,
         shipping_app,
-        EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
+        subscribable_object=order_with_lines,
+        timeout=EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
     )
     mocked_webhook.assert_any_call(
         WebhookEventSyncType.ORDER_FILTER_SHIPPING_METHODS,
         payload,
         second_shipping_app,
-        EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
+        subscribable_object=order_with_lines,
+        timeout=EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
     )
     expected_cache_key = CACHE_EXCLUDED_SHIPPING_KEY + str(order_with_lines.id)
 
@@ -464,7 +467,8 @@ def test_excluded_shipping_methods_for_checkout(
         WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
         payload,
         shipping_app,
-        EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
+        subscribable_object=checkout_with_items,
+        timeout=EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
     )
 
     expected_cache_key = CACHE_EXCLUDED_SHIPPING_KEY + str(checkout_with_items.token)
@@ -544,13 +548,15 @@ def test_multiple_app_with_excluded_shipping_methods_for_checkout(
         WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
         payload,
         shipping_app,
-        EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
+        subscribable_object=checkout_with_items,
+        timeout=EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
     )
     mocked_webhook.assert_any_call(
         WebhookEventSyncType.CHECKOUT_FILTER_SHIPPING_METHODS,
         payload,
         second_shipping_app,
-        EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
+        subscribable_object=checkout_with_items,
+        timeout=EXCLUDED_SHIPPING_REQUEST_TIMEOUT,
     )
 
     expected_cache_key = CACHE_EXCLUDED_SHIPPING_KEY + str(checkout_with_items.token)


### PR DESCRIPTION
* WIP add sync webhooks subscription payload handling

* add tests, fix minor things

* update schema

* remove unneeded code

* add fix for circular field resolve

* fix-filter-shipping-methods-payload

* added_in added to desription

* add missing types

* revert refactor, precommit issues

* fixes after review

* cosmetix fixes post-review

* subscription types description fixes

* remove unneeded description from PaymentBase

* add validation for creating webhook with two top level fields, add tests for shippingListMethodsForCheckout

* add docstring, refactor prevent_sync_event_circular_wuery wrapper

* fix docstring of revent_sync_event_circular_query

* fix linters