### PR TITLE
App dataloader

### DIFF
--- a/saleor/app/models.py
+++ b/saleor/app/models.py
@@ -1,4 +1,4 @@
-from typing import Collection, Set, Union
+from typing import Collection, Set, Tuple, Union
 
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import Permission
@@ -116,6 +116,11 @@ class AppTokenManager(models.Manager):
         app_token.set_auth_token(auth_token)
         app_token.save()
         return app_token, auth_token
+
+    def create_with_token(self, *args, **kwargs) -> Tuple["AppToken", str]:
+        # As `create` is waiting to be fixed, I'm using this proper method from future
+        # to get both AppToken and auth_token.
+        return self.create(*args, **kwargs)
 
 
 class AppToken(models.Model):

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -22,6 +22,7 @@ from ....graphql.utils import get_user_or_app_from_context
 from ....order.utils import match_orders_with_new_user
 from ...account.i18n import I18nMixin
 from ...account.types import Address, AddressInput, User
+from ...app.dataloaders import load_app
 from ...channel.utils import clean_channel, validate_channel
 from ...core.enums import LanguageCodeEnum
 from ...core.mutations import (
@@ -49,7 +50,8 @@ def check_can_edit_address(context, address):
     requester = get_user_or_app_from_context(context)
     if requester.has_perm(AccountPermissions.MANAGE_USERS):
         return True
-    if not context.app and not context.user.is_anonymous:
+    app = load_app(context)
+    if not app and not context.user.is_anonymous:
         is_owner = requester.addresses.filter(pk=address.pk).exists()
         if is_owner:
             return True

--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -17,6 +17,7 @@ from ...account.utils import (
     get_out_of_scope_permissions,
     get_out_of_scope_users,
 )
+from ...app.dataloaders import load_app
 from ...core.enums import PermissionEnum
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types import NonNullList, PermissionGroupError
@@ -109,7 +110,8 @@ class PermissionGroupCreate(ModelMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if context.app:
+        app = load_app(context)
+        if app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )
@@ -456,7 +458,8 @@ class PermissionGroupDelete(ModelDeleteMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if context.app:
+        app = load_app(context)
+        if app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -24,6 +24,7 @@ from ....order.utils import match_orders_with_new_user
 from ....thumbnail import models as thumbnail_models
 from ...account.enums import AddressTypeEnum
 from ...account.types import Address, AddressInput, User
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ...core.types import AccountError, NonNullList, StaffError, Upload
 from ...core.utils import add_hash_to_file_name, validate_image_file
@@ -105,7 +106,7 @@ class CustomerUpdate(CustomerCreate):
     ):
         # Retrieve the event base data
         staff_user = info.context.user
-        app = info.context.app
+        app = load_app(info.context)
         new_email = new_instance.email
         new_fullname = new_instance.get_full_name()
 
@@ -129,13 +130,13 @@ class CustomerUpdate(CustomerCreate):
         if was_activated:
             account_events.customer_account_activated_event(
                 staff_user=info.context.user,
-                app=info.context.app,
+                app=app,
                 account_id=old_instance.id,
             )
         if was_deactivated:
             account_events.customer_account_deactivated_event(
                 staff_user=info.context.user,
-                app=info.context.app,
+                app=app,
                 account_id=old_instance.id,
             )
 
@@ -214,7 +215,8 @@ class StaffCreate(ModelMutation):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if context.app:
+        app = load_app(context)
+        if app:
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -16,6 +16,7 @@ from ...core.permissions import (
 from ...core.tracing import traced_resolver
 from ...payment import gateway
 from ...payment.utils import fetch_customer_id
+from ..app.dataloaders import load_app
 from ..core.utils import from_global_id_or_error
 from ..meta.resolvers import resolve_metadata
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
@@ -201,7 +202,7 @@ def prepare_graphql_payment_sources_type(payment_sources):
 @traced_resolver
 def resolve_address(info, id):
     user = info.context.user
-    app = info.context.app
+    app = load_app(info.context)
     _, address_pk = from_global_id_or_error(id, Address)
     if app and app.has_perm(AccountPermissions.MANAGE_USERS):
         return models.Address.objects.filter(pk=address_pk).first()
@@ -214,7 +215,7 @@ def resolve_address(info, id):
 
 def resolve_addresses(info, ids):
     user = info.context.user
-    app = info.context.app
+    app = load_app(info.context)
     ids = [
         from_global_id_or_error(address_id, Address, raise_error=True)[1]
         for address_id in ids

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -17,6 +17,7 @@ from ...core.permissions import (
     AuthorizationFilters,
     has_one_of_permissions,
 )
+from ..app.dataloaders import load_app
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
@@ -71,9 +72,10 @@ class CustomerDeleteMixin(UserDeleteMixin):
 
     @classmethod
     def post_process(cls, info, deleted_count=1):
+        app = load_app(info.context)
         account_events.customer_deleted_event(
             staff_user=info.context.user,
-            app=info.context.app,
+            app=app,
             deleted_count=deleted_count,
         )
 
@@ -84,7 +86,7 @@ class StaffDeleteMixin(UserDeleteMixin):
 
     @classmethod
     def check_permissions(cls, context, permissions=None):
-        if context.app:
+        if load_app(context):
             raise PermissionDenied(
                 message="Apps are not allowed to perform this mutation."
             )

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -7,7 +7,7 @@ from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
 from ..core.fields import FilterConnectionField, PermissionsField
 from ..core.types import FilterInputObjectType, NonNullList
 from ..core.utils import from_global_id_or_error
-from .dataloaders import AppByIdLoader, AppExtensionByIdLoader
+from .dataloaders import AppByIdLoader, AppExtensionByIdLoader, load_app
 from .filters import AppExtensionFilter, AppFilter
 from .mutations import (
     AppActivate,
@@ -120,7 +120,7 @@ class AppQueries(graphene.ObjectType):
 
     @staticmethod
     def resolve_app(_root, info, *, id=None):
-        if app := info.context.app:
+        if app := load_app(info.context):
             if not id:
                 return app
             _, app_id = from_global_id_or_error(id, only_type="App")

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -26,7 +26,7 @@ from ..meta.types import ObjectWithMetadata
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
 from ..webhook.enums import WebhookEventTypeAsyncEnum, WebhookEventTypeSyncEnum
 from ..webhook.types import Webhook
-from .dataloaders import AppByIdLoader, AppExtensionByAppIdLoader
+from .dataloaders import AppByIdLoader, AppExtensionByAppIdLoader, load_app
 from .enums import AppExtensionMountEnum, AppExtensionTargetEnum, AppTypeEnum
 from .resolvers import (
     resolve_access_token_for_app,
@@ -56,7 +56,8 @@ def has_access_to_app_public_meta(root, info) -> bool:
     if auth_token.get("type") == JWT_THIRDPARTY_ACCESS_TYPE:
         _, app_id = from_global_id_or_error(auth_token["app"], "App")
     else:
-        app_id = info.context.app.id if info.context.app else None
+        app = load_app(info.context)
+        app_id = app.id if app else None
     if app_id is not None and int(app_id) == root.id:
         return True
     requester = get_user_or_app_from_context(info.context)
@@ -125,7 +126,7 @@ class AppExtension(AppManifestExtension, ModelObjectType):
     @staticmethod
     def resolve_app(root, info):
         app_id = None
-        app = info.context.app
+        app = load_app(info.context)
         if app and app.id == root.app_id:
             app_id = root.app_id
         else:

--- a/saleor/graphql/checkout/mutations/checkout_complete.py
+++ b/saleor/graphql/checkout/mutations/checkout_complete.py
@@ -19,6 +19,7 @@ from ....core.permissions import AccountPermissions
 from ....core.transactions import transaction_with_commit_on_errors
 from ....order import models as order_models
 from ...account.i18n import I18nMixin
+from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.fields import JSONString
 from ...core.mutations import BaseMutation
@@ -255,7 +256,7 @@ class CheckoutComplete(BaseMutation, I18nMixin):
                 store_source=store_source,
                 discounts=info.context.discounts,
                 user=customer,
-                app=info.context.app,
+                app=load_app(info.context),
                 site_settings=info.context.site.settings,
                 tracking_code=tracking_code,
                 redirect_url=data.get("redirect_url"),

--- a/saleor/graphql/checkout/mutations/checkout_create.py
+++ b/saleor/graphql/checkout/mutations/checkout_create.py
@@ -11,6 +11,7 @@ from ....product import models as product_models
 from ....warehouse.reservations import get_reservation_length, is_reservation_enabled
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
+from ...app.dataloaders import load_app
 from ...channel.utils import clean_channel
 from ...core.descriptions import (
     ADDED_IN_31,
@@ -168,7 +169,8 @@ class CheckoutCreate(ModelMutation, I18nMixin):
     def clean_checkout_lines(
         cls, info, lines, country, channel
     ) -> Tuple[List[product_models.ProductVariant], List["CheckoutLineData"]]:
-        check_permissions_for_custom_prices(info.context.app, lines)
+        app = load_app(info.context)
+        check_permissions_for_custom_prices(app, lines)
         variant_ids = [line["variant_id"] for line in lines]
         variants = cls.get_nodes_or_error(
             variant_ids,

--- a/saleor/graphql/checkout/mutations/checkout_lines_add.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_add.py
@@ -10,6 +10,7 @@ from ....checkout.fetch import (
 )
 from ....checkout.utils import add_variants_to_checkout, invalidate_checkout_prices
 from ....warehouse.reservations import get_reservation_length, is_reservation_enabled
+from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_34, DEPRECATED_IN_3X_INPUT
 from ...core.mutations import BaseMutation
 from ...core.scalars import UUID
@@ -164,7 +165,8 @@ class CheckoutLinesAdd(BaseMutation):
     def perform_mutation(
         cls, _root, info, lines, checkout_id=None, token=None, id=None, replace=False
     ):
-        check_permissions_for_custom_prices(info.context.app, lines)
+        app = load_app(info.context)
+        check_permissions_for_custom_prices(app, lines)
 
         checkout = get_checkout(
             cls,

--- a/saleor/graphql/checkout/mutations/checkout_lines_update.py
+++ b/saleor/graphql/checkout/mutations/checkout_lines_update.py
@@ -5,6 +5,7 @@ from django.forms import ValidationError
 
 from ....checkout.error_codes import CheckoutErrorCode
 from ....warehouse.reservations import is_reservation_enabled
+from ...app.dataloaders import load_app
 from ...checkout.types import CheckoutLine
 from ...core.descriptions import (
     ADDED_IN_31,
@@ -129,8 +130,9 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
         discounts,
         replace,
     ):
+        app = load_app(info.context)
         # if the requestor is not app, the quantity is required for all lines
-        if not info.context.app:
+        if not app:
             if any(
                 [
                     line_data.quantity_to_update is False

--- a/saleor/graphql/checkout/mutations/order_create_from_checkout.py
+++ b/saleor/graphql/checkout/mutations/order_create_from_checkout.py
@@ -8,6 +8,7 @@ from ....core import analytics
 from ....core.exceptions import GiftCardNotApplicable, InsufficientStock
 from ....core.permissions import CheckoutPermissions
 from ....discount.models import NotApplicable
+from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_32, PREVIEW_FEATURE
 from ...core.mutations import BaseMutation
 from ...core.types import Error
@@ -96,7 +97,7 @@ class OrderCreateFromCheckout(BaseMutation):
             discounts=discounts,
             manager=manager,
         )
-
+        app = load_app(info.context)
         try:
             order = create_order_from_checkout(
                 checkout_info=checkout_info,
@@ -104,7 +105,7 @@ class OrderCreateFromCheckout(BaseMutation):
                 discounts=info.context.discounts,
                 manager=info.context.plugins,
                 user=info.context.user,
-                app=info.context.app,
+                app=app,
                 tracking_code=tracking_code,
                 delete_checkout=data["remove_checkout"],
             )

--- a/saleor/graphql/context.py
+++ b/saleor/graphql/context.py
@@ -1,16 +1,16 @@
 from typing import Optional, Protocol, Union, cast
 
 from django.contrib.auth import authenticate
-from django.contrib.auth.hashers import check_password
 from django.contrib.auth.models import AnonymousUser
-from django.db.models import Exists, OuterRef
 from django.utils.functional import SimpleLazyObject
+from promise import Promise
 
 from ..account.models import User
-from ..app.models import App, AppToken
+from ..app.models import App
 from ..core.auth import get_token_from_request
 from ..core.jwt import jwt_decode_with_exception_handler
 from .api import API_PATH
+from .app.dataloaders import load_app
 
 
 def get_context_value(request):
@@ -26,33 +26,18 @@ UserType = Union[User, AnonymousUser]
 class RequestWithUser(Protocol):
     _cached_user: UserType
     app: Optional[App]
-    user: Union[UserType, SimpleLazyObject]
-
-
-def get_app(raw_auth_token) -> Optional[App]:
-    tokens = AppToken.objects.filter(token_last_4=raw_auth_token[-4:]).values_list(
-        "id", "auth_token"
-    )
-    token_ids = [
-        id for id, auth_token in tokens if check_password(raw_auth_token, auth_token)
-    ]
-    return App.objects.filter(
-        Exists(tokens.filter(id__in=token_ids, app_id=OuterRef("pk"))), is_active=True
-    ).first()
+    user: Union[UserType, SimpleLazyObject, Promise]
 
 
 def set_decoded_auth_token(request):
-    token = get_token_from_request(request)
-    decoded_auth_token = jwt_decode_with_exception_handler(token)
+    auth_token = get_token_from_request(request)
+    decoded_auth_token = jwt_decode_with_exception_handler(auth_token)
     request.decoded_auth_token = decoded_auth_token
 
 
 def set_app_on_context(request):
     if request.path == API_PATH and not hasattr(request, "app"):
-        request.app = None
-        auth_token = get_token_from_request(request)
-        if auth_token and len(auth_token) == 30:
-            request.app = SimpleLazyObject(lambda: get_app(auth_token))
+        request.app = load_app(request)
 
 
 def get_user(request: RequestWithUser) -> Optional[UserType]:

--- a/saleor/graphql/core/dataloaders.py
+++ b/saleor/graphql/core/dataloaders.py
@@ -33,7 +33,7 @@ class DataLoader(BaseLoader, Generic[K, R]):
     def __init__(self, context):
         if self.context != context:
             self.context = context
-            self.user = context.user
+            self.user = getattr(context, "user", None)
             super().__init__()
 
     def batch_load_fn(self, keys: Iterable[K]) -> Promise[List[R]]:

--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -31,7 +31,7 @@ class Mutation(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, product_id, channel):
         # Need to mock `app_middleware`
-        info.context.app = None
+        info.context.auth_token = None
 
         product = cls.get_node_or_error(
             info, product_id, field="product_id", only_type=product_types.Product
@@ -73,7 +73,7 @@ class OrderMutation(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, id, channel):
         # Need to mock `app_middleware`
-        info.context.app = None
+        info.context.auth_token = None
 
         order = cls.get_node_or_error(info, id, only_type=order_types.Order)
         return OrderMutation(number=order.number)
@@ -371,29 +371,24 @@ def test_mutation_calls_plugin_perform_mutation_after_permission_checks(
     assert result.errors[0].message == "My Custom Error"
 
 
-def test_base_mutation_get_node_by_pk_with_order_qs_and_old_int_id(staff_user, order):
+def test_base_mutation_get_node_by_pk_with_order_qs_and_old_int_id(order):
     # given
     order.use_old_id = True
     order.save(update_fields=["use_old_id"])
 
-    info = mock.Mock(context=mock.Mock(user=staff_user))
-
     # when
     node = BaseMutation._get_node_by_pk(
-        info, order_types.Order, order.number, qs=Order.objects.all()
+        None, order_types.Order, order.number, qs=Order.objects.all()
     )
 
     # then
     assert node.id == order.id
 
 
-def test_base_mutation_get_node_by_pk_with_order_qs_and_new_uuid_id(staff_user, order):
-    # given
-    info = mock.Mock(context=mock.Mock(user=staff_user))
-
+def test_base_mutation_get_node_by_pk_with_order_qs_and_new_uuid_id(order):
     # when
     node = BaseMutation._get_node_by_pk(
-        info, order_types.Order, order.pk, qs=Order.objects.all()
+        None, order_types.Order, order.pk, qs=Order.objects.all()
     )
 
     # then
@@ -401,30 +396,25 @@ def test_base_mutation_get_node_by_pk_with_order_qs_and_new_uuid_id(staff_user, 
 
 
 def test_base_mutation_get_node_by_pk_with_order_qs_and_int_id_use_old_id_set_to_false(
-    staff_user, order
+    order,
 ):
     # given
     order.use_old_id = False
     order.save(update_fields=["use_old_id"])
 
-    info = mock.Mock(context=mock.Mock(user=staff_user))
-
     # when
     node = BaseMutation._get_node_by_pk(
-        info, order_types.Order, order.number, qs=Order.objects.all()
+        None, order_types.Order, order.number, qs=Order.objects.all()
     )
 
     # then
     assert node is None
 
 
-def test_base_mutation_get_node_by_pk_with_qs_for_product(staff_user, product):
-    # given
-    info = mock.Mock(context=mock.Mock(user=staff_user))
-
+def test_base_mutation_get_node_by_pk_with_qs_for_product(product):
     # when
     node = BaseMutation._get_node_by_pk(
-        info, product_types.Product, product.pk, qs=Product.objects.all()
+        None, product_types.Product, product.pk, qs=Product.objects.all()
     )
 
     # then

--- a/saleor/graphql/csv/mutations.py
+++ b/saleor/graphql/csv/mutations.py
@@ -7,6 +7,7 @@ from ...core.permissions import GiftcardPermissions, ProductPermissions
 from ...csv import models as csv_models
 from ...csv.events import export_started_event
 from ...csv.tasks import export_gift_cards_task, export_products_task
+from ..app.dataloaders import load_app
 from ..attribute.types import Attribute
 from ..channel.types import Channel
 from ..core.descriptions import ADDED_IN_31, PREVIEW_FEATURE
@@ -129,7 +130,7 @@ class ExportProducts(BaseExportMutation):
         export_info = cls.get_export_info(input["export_info"])
         file_type = input["file_type"]
 
-        app = info.context.app
+        app = load_app(info.context)
         kwargs = {"app": app} if app else {"user": info.context.user}
 
         export_file = csv_models.ExportFile.objects.create(**kwargs)
@@ -198,7 +199,7 @@ class ExportGiftCards(BaseExportMutation):
         scope = cls.get_scope(input, GiftCard)
         file_type = input["file_type"]
 
-        app = info.context.app
+        app = load_app(info.context)
         kwargs = {"app": app} if app else {"user": info.context.user}
 
         export_file = csv_models.ExportFile.objects.create(**kwargs)

--- a/saleor/graphql/order/bulk_mutations/orders.py
+++ b/saleor/graphql/order/bulk_mutations/orders.py
@@ -3,6 +3,7 @@ import graphene
 from ....core.permissions import OrderPermissions
 from ....order import models
 from ....order.actions import cancel_order
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseBulkMutation
 from ...core.types import NonNullList, OrderError
 from ..mutations.order_cancel import clean_order_cancel
@@ -33,6 +34,6 @@ class OrderBulkCancel(BaseBulkMutation):
             cancel_order(
                 order=order,
                 user=info.context.user,
-                app=info.context.app,
+                app=load_app(info.context),
                 manager=info.context.plugins,
             )

--- a/saleor/graphql/order/mutations/draft_order_complete.py
+++ b/saleor/graphql/order/mutations/draft_order_complete.py
@@ -17,6 +17,7 @@ from ....order.search import prepare_order_search_vector_value
 from ....order.utils import get_order_country
 from ....warehouse.management import allocate_preorders, allocate_stocks
 from ....warehouse.reservations import is_reservation_enabled
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ..types import Order
@@ -129,14 +130,14 @@ class DraftOrderComplete(BaseMutation):
             payment=order.get_last_payment(),
             lines_data=order_lines_info,
         )
+        app = load_app(info.context)
         transaction.on_commit(
             lambda: order_created(
                 order_info=order_info,
                 user=info.context.user,
-                app=info.context.app,
+                app=app,
                 manager=info.context.plugins,
                 from_draft=True,
             )
         )
-
         return DraftOrderComplete(order=order)

--- a/saleor/graphql/order/mutations/draft_order_create.py
+++ b/saleor/graphql/order/mutations/draft_order_create.py
@@ -22,6 +22,7 @@ from ....order.utils import (
 )
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
+from ...app.dataloaders import load_app
 from ...channel.types import Channel
 from ...core.descriptions import ADDED_IN_36, PREVIEW_FEATURE
 from ...core.mutations import ModelMutation
@@ -289,10 +290,11 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
                 lines.append(new_line)
 
             # New event
+            app = load_app(info.context)
             events.order_added_products_event(
                 order=instance,
                 user=info.context.user,
-                app=info.context.app,
+                app=app,
                 order_lines=lines,
             )
 
@@ -302,8 +304,9 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
 
         # Create draft created event if the instance is from scratch
         if is_new_instance:
+            app = load_app(info.context)
             events.draft_order_created_event(
-                order=instance, user=info.context.user, app=info.context.app
+                order=instance, user=info.context.user, app=app
             )
 
         instance.save(

--- a/saleor/graphql/order/mutations/fulfillment_approve.py
+++ b/saleor/graphql/order/mutations/fulfillment_approve.py
@@ -6,6 +6,7 @@ from ....core.permissions import OrderPermissions
 from ....order import FulfillmentStatus
 from ....order.actions import approve_fulfillment
 from ....order.error_codes import OrderErrorCode
+from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_31
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
@@ -61,10 +62,11 @@ class FulfillmentApprove(BaseMutation):
         order = fulfillment.order
 
         try:
+            app = load_app(info.context)
             fulfillment = approve_fulfillment(
                 fulfillment,
                 info.context.user,
-                info.context.app,
+                app,
                 info.context.plugins,
                 info.context.site.settings,
                 notify_customer=data["notify_customer"],

--- a/saleor/graphql/order/mutations/fulfillment_cancel.py
+++ b/saleor/graphql/order/mutations/fulfillment_cancel.py
@@ -6,6 +6,7 @@ from ....giftcard.utils import order_has_gift_card_lines
 from ....order import FulfillmentStatus
 from ....order.actions import cancel_fulfillment, cancel_waiting_fulfillment
 from ....order.error_codes import OrderErrorCode
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ..types import Fulfillment, Order
@@ -89,18 +90,19 @@ class FulfillmentCancel(BaseMutation):
 
         cls.validate_fulfillment(fulfillment, warehouse)
 
+        app = load_app(info.context)
         if fulfillment.status == FulfillmentStatus.WAITING_FOR_APPROVAL:
             fulfillment = cancel_waiting_fulfillment(
                 fulfillment,
                 info.context.user,
-                info.context.app,
+                app,
                 info.context.plugins,
             )
         else:
             fulfillment = cancel_fulfillment(
                 fulfillment,
                 info.context.user,
-                info.context.app,
+                app,
                 warehouse,
                 info.context.plugins,
             )

--- a/saleor/graphql/order/mutations/fulfillment_refund_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_refund_products.py
@@ -5,6 +5,7 @@ from ....order import FulfillmentStatus
 from ....order import models as order_models
 from ....order.actions import create_refund_fulfillment
 from ....payment import PaymentError
+from ...app.dataloaders import load_app
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
 from ..types import Fulfillment, Order
@@ -133,9 +134,10 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
         order = cleaned_input["order"]
 
         try:
+            app = load_app(info.context)
             refund_fulfillment = create_refund_fulfillment(
                 info.context.user,
-                info.context.app,
+                app,
                 order,
                 cleaned_input["payment"],
                 cleaned_input["transactions"],

--- a/saleor/graphql/order/mutations/fulfillment_return_products.py
+++ b/saleor/graphql/order/mutations/fulfillment_return_products.py
@@ -5,6 +5,7 @@ from ....order import FulfillmentStatus
 from ....order import models as order_models
 from ....order.actions import create_fulfillments_for_returned_products
 from ....payment import PaymentError
+from ...app.dataloaders import load_app
 from ...core.scalars import PositiveDecimal
 from ...core.types import NonNullList, OrderError
 from ..types import Fulfillment, Order
@@ -155,9 +156,10 @@ class FulfillmentReturnProducts(FulfillmentRefundAndReturnProductBase):
         cleaned_input = cls.clean_input(info, data.get("order"), data.get("input"))
         order = cleaned_input["order"]
         try:
+            app = load_app(info.context)
             response = create_fulfillments_for_returned_products(
                 info.context.user,
-                info.context.app,
+                app,
                 order,
                 cleaned_input.get("payment"),
                 cleaned_input.get("transactions"),

--- a/saleor/graphql/order/mutations/fulfillment_update_tracking.py
+++ b/saleor/graphql/order/mutations/fulfillment_update_tracking.py
@@ -3,6 +3,7 @@ import graphene
 from ....core.permissions import OrderPermissions
 from ....order.actions import fulfillment_tracking_updated
 from ....order.notifications import send_fulfillment_update
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ..types import Fulfillment, Order
@@ -36,10 +37,11 @@ class FulfillmentUpdateTracking(BaseMutation):
         fulfillment.tracking_number = tracking_number
         fulfillment.save()
         order = fulfillment.order
+        app = load_app(info.context)
         fulfillment_tracking_updated(
             fulfillment,
             info.context.user,
-            info.context.app,
+            app,
             tracking_number,
             info.context.plugins,
         )

--- a/saleor/graphql/order/mutations/order_add_note.py
+++ b/saleor/graphql/order/mutations/order_add_note.py
@@ -6,6 +6,7 @@ from ....core.permissions import OrderPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.error_codes import OrderErrorCode
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ...core.utils import validate_required_string_field
@@ -59,10 +60,11 @@ class OrderAddNote(BaseMutation):
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         cleaned_input = cls.clean_input(info, order, data)
+        app = load_app(info.context)
         event = events.order_note_added_event(
             order=order,
             user=info.context.user,
-            app=info.context.app,
+            app=app,
             message=cleaned_input["message"],
         )
         func = get_webhook_handler_by_order_status(order.status, info)

--- a/saleor/graphql/order/mutations/order_cancel.py
+++ b/saleor/graphql/order/mutations/order_cancel.py
@@ -6,6 +6,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....giftcard.utils import deactivate_order_gift_cards
 from ....order.actions import cancel_order
 from ....order.error_codes import OrderErrorCode
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ..types import Order
@@ -41,7 +42,7 @@ class OrderCancel(BaseMutation):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
         clean_order_cancel(order)
         user = info.context.user
-        app = info.context.app
+        app = load_app(info.context)
         cancel_order(
             order=order,
             user=user,

--- a/saleor/graphql/order/mutations/order_confirm.py
+++ b/saleor/graphql/order/mutations/order_confirm.py
@@ -10,6 +10,7 @@ from ....order.error_codes import OrderErrorCode
 from ....order.fetch import fetch_order_info
 from ....payment import PaymentError, gateway
 from ....payment.gateway import request_charge_action
+from ...app.dataloaders import load_app
 from ...core.mutations import ModelMutation
 from ...core.types import OrderError
 from ..types import Order
@@ -62,6 +63,8 @@ class OrderConfirm(ModelMutation):
         order_info = fetch_order_info(order)
         payment = order_info.payment
         manager = info.context.plugins
+        app = load_app(info.context)
+
         if payment_transactions := list(order.payment_transactions.all()):
             try:
                 # We use the last transaction as we don't have a possibility to
@@ -73,7 +76,7 @@ class OrderConfirm(ModelMutation):
                     charge_value=payment_transaction.authorized_value,
                     channel_slug=order.channel.slug,
                     user=info.context.user,
-                    app=info.context.app,
+                    app=app,
                 )
             except PaymentError as e:
                 raise ValidationError(
@@ -88,7 +91,7 @@ class OrderConfirm(ModelMutation):
                 lambda: order_captured(
                     order_info,
                     info.context.user,
-                    info.context.app,
+                    app,
                     payment.total,
                     payment,
                     manager,
@@ -99,7 +102,7 @@ class OrderConfirm(ModelMutation):
             lambda: order_confirmed(
                 order,
                 info.context.user,
-                info.context.app,
+                app,
                 manager,
                 send_confirmation_email=True,
             )

--- a/saleor/graphql/order/mutations/order_discount_add.py
+++ b/saleor/graphql/order/mutations/order_discount_add.py
@@ -7,6 +7,7 @@ from ....order import events
 from ....order.calculations import fetch_order_prices_if_expired
 from ....order.error_codes import OrderErrorCode
 from ....order.utils import create_order_discount_for_order, get_order_discounts
+from ...app.dataloaders import load_app
 from ...core.types import OrderError
 from ..types import Order
 from .order_discount_common import OrderDiscountCommon, OrderDiscountCommonInput
@@ -63,8 +64,9 @@ class OrderDiscountAdd(OrderDiscountCommon):
         order_discount = create_order_discount_for_order(
             order, reason, value_type, value
         )
+        app = load_app(info.context)
 
-        # Calling refreshing prices because it's set proper discount amount on
+        # Calling refreshing prices because it's set proper discount amount
         # on OrderDiscount.
         order, _ = fetch_order_prices_if_expired(order, manager, force_update=True)
         order_discount.refresh_from_db()
@@ -72,7 +74,7 @@ class OrderDiscountAdd(OrderDiscountCommon):
         events.order_discount_added_event(
             order=order,
             user=info.context.user,
-            app=info.context.app,
+            app=app,
             order_discount=order_discount,
         )
         return OrderDiscountAdd(order=order)

--- a/saleor/graphql/order/mutations/order_discount_delete.py
+++ b/saleor/graphql/order/mutations/order_discount_delete.py
@@ -5,6 +5,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.search import update_order_search_vector
 from ....order.utils import invalidate_order_prices, remove_order_discount_from_order
+from ...app.dataloaders import load_app
 from ...core.types import OrderError
 from ..types import Order
 from .order_discount_common import OrderDiscountCommon
@@ -31,13 +32,15 @@ class OrderDiscountDelete(OrderDiscountCommon):
             info, data.get("discount_id"), only_type="OrderDiscount"
         )
         order = order_discount.order
+        app = load_app(info.context)
+
         cls.validate_order(info, order)
 
         remove_order_discount_from_order(order, order_discount)
         events.order_discount_deleted_event(
             order=order,
             user=info.context.user,
-            app=info.context.app,
+            app=app,
             order_discount=order_discount,
         )
 

--- a/saleor/graphql/order/mutations/order_discount_update.py
+++ b/saleor/graphql/order/mutations/order_discount_update.py
@@ -6,6 +6,7 @@ from ....core.permissions import OrderPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.calculations import fetch_order_prices_if_expired
+from ...app.dataloaders import load_app
 from ...core.types import OrderError
 from ..types import Order
 from .order_discount_common import OrderDiscountCommon, OrderDiscountCommonInput
@@ -63,14 +64,15 @@ class OrderDiscountUpdate(OrderDiscountCommon):
             or order_discount_before_update.value != value
         ):
             # call update event only when we changed the type or value of the discount
-            # Calling refreshing prices because it's set proper discount amount on
+            # Calling refreshing prices because it's set proper discount amount
             # on OrderDiscount.
             fetch_order_prices_if_expired(order, manager, force_update=True)
             order_discount.refresh_from_db()
+            app = load_app(info.context)
             events.order_discount_updated_event(
                 order=order,
                 user=info.context.user,
-                app=info.context.app,
+                app=app,
                 order_discount=order_discount,
                 old_order_discount=order_discount_before_update,
             )

--- a/saleor/graphql/order/mutations/order_fulfill.py
+++ b/saleor/graphql/order/mutations/order_fulfill.py
@@ -10,6 +10,7 @@ from ....core.tracing import traced_atomic_transaction
 from ....order import models as order_models
 from ....order.actions import create_fulfillments
 from ....order.error_codes import OrderErrorCode
+from ...app.dataloaders import load_app
 from ...core.descriptions import ADDED_IN_36
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
@@ -245,7 +246,7 @@ class OrderFulfill(BaseMutation):
 
         context = info.context
         user = context.user if not context.user.is_anonymous else None
-        app = context.app
+        app = load_app(info.context)
         manager = context.plugins
         lines_for_warehouses = cleaned_input["lines_for_warehouses"]
         notify_customer = cleaned_input.get("notify_customer", True)

--- a/saleor/graphql/order/mutations/order_line_delete.py
+++ b/saleor/graphql/order/mutations/order_line_delete.py
@@ -12,6 +12,7 @@ from ....order.utils import (
     invalidate_order_prices,
     recalculate_order_weight,
 )
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ..types import Order, OrderLine
@@ -74,10 +75,11 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
                 "updated_at",
             ]
         # Create the removal event
+        app = load_app(info.context)
         events.order_removed_products_event(
             order=order,
             user=info.context.user,
-            app=info.context.app,
+            app=app,
             order_lines=[line],
         )
 

--- a/saleor/graphql/order/mutations/order_line_discount_remove.py
+++ b/saleor/graphql/order/mutations/order_line_discount_remove.py
@@ -4,6 +4,7 @@ from ....core.permissions import OrderPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.utils import invalidate_order_prices, remove_discount_from_order_line
+from ...app.dataloaders import load_app
 from ...core.types import OrderError
 from ..types import Order, OrderLine
 from .order_discount_common import OrderDiscountCommon
@@ -45,11 +46,11 @@ class OrderLineDiscountRemove(OrderDiscountCommon):
         remove_discount_from_order_line(
             order_line, order, manager=info.context.plugins, tax_included=tax_included
         )
-
+        app = load_app(info.context)
         events.order_line_discount_removed_event(
             order=order,
             user=info.context.user,
-            app=info.context.app,
+            app=app,
             line=order_line,
         )
 

--- a/saleor/graphql/order/mutations/order_line_discount_update.py
+++ b/saleor/graphql/order/mutations/order_line_discount_update.py
@@ -6,6 +6,7 @@ from ....core.permissions import OrderPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....order import events
 from ....order.utils import invalidate_order_prices, update_discount_for_order_line
+from ...app.dataloaders import load_app
 from ...core.types import OrderError
 from ..types import Order, OrderLine
 from .order_discount_common import OrderDiscountCommon, OrderDiscountCommonInput
@@ -75,10 +76,11 @@ class OrderLineDiscountUpdate(OrderDiscountCommon):
             or order_line_before_update.unit_discount_type != value_type
         ):
             # Create event only when we change type or value of the discount
+            app = load_app(info.context)
             events.order_line_discount_updated_event(
                 order=order,
                 user=info.context.user,
-                app=info.context.app,
+                app=app,
                 line=order_line,
                 line_before_update=order_line_before_update,
             )

--- a/saleor/graphql/order/mutations/order_line_update.py
+++ b/saleor/graphql/order/mutations/order_line_update.py
@@ -13,6 +13,7 @@ from ....order.utils import (
     invalidate_order_prices,
     recalculate_order_weight,
 )
+from ...app.dataloaders import load_app
 from ...core.mutations import ModelMutation
 from ...core.types import OrderError
 from ..types import Order, OrderLine
@@ -70,10 +71,11 @@ class OrderLineUpdate(EditableOrderValidationMixin, ModelMutation):
             variant=instance.variant,
             warehouse_pk=warehouse_pk,
         )
+        app = load_app(info.context)
         try:
             change_order_line_quantity(
                 info.context.user,
-                info.context.app,
+                app,
                 line_info,
                 instance.old_quantity,
                 instance.quantity,

--- a/saleor/graphql/order/mutations/order_lines_create.py
+++ b/saleor/graphql/order/mutations/order_lines_create.py
@@ -17,6 +17,7 @@ from ....order.utils import (
     invalidate_order_prices,
     recalculate_order_weight,
 )
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import NonNullList, OrderError
 from ...product.types import ProductVariant
@@ -151,12 +152,13 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         lines_to_add = cls.validate_lines(info, data, existing_lines_info)
         variants = [line.variant for line in lines_to_add]
         cls.validate_variants(order, variants)
+        app = load_app(info.context)
 
         added_lines = cls.add_lines_to_order(
             order,
             lines_to_add,
             info.context.user,
-            info.context.app,
+            app,
             info.context.plugins,
             info.context.site.settings,
             info.context.discounts,
@@ -166,7 +168,7 @@ class OrderLinesCreate(EditableOrderValidationMixin, BaseMutation):
         events.order_added_products_event(
             order=order,
             user=info.context.user,
-            app=info.context.app,
+            app=app,
             order_lines=added_lines,
         )
 

--- a/saleor/graphql/order/mutations/order_mark_as_paid.py
+++ b/saleor/graphql/order/mutations/order_mark_as_paid.py
@@ -6,6 +6,7 @@ from ....order.actions import clean_mark_order_as_paid, mark_order_as_paid
 from ....order.calculations import fetch_order_prices_if_expired
 from ....order.error_codes import OrderErrorCode
 from ....order.search import update_order_search_vector
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ..types import Order
@@ -43,7 +44,7 @@ class OrderMarkAsPaid(BaseMutation):
         transaction_reference = data.get("transaction_reference")
         cls.clean_billing_address(order)
         user = info.context.user
-        app = info.context.app
+        app = load_app(info.context)
         try_payment_action(order, user, app, None, clean_mark_order_as_paid, order)
 
         mark_order_as_paid(

--- a/saleor/graphql/order/mutations/order_void.py
+++ b/saleor/graphql/order/mutations/order_void.py
@@ -6,6 +6,7 @@ from ....order.actions import order_voided
 from ....order.error_codes import OrderErrorCode
 from ....payment import PaymentError, TransactionKind, gateway
 from ....payment.gateway import request_void_action
+from ...app.dataloaders import load_app
 from ...core.mutations import BaseMutation
 from ...core.types import OrderError
 from ..types import Order
@@ -41,6 +42,7 @@ class OrderVoid(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(info, data.get("id"), only_type=Order)
+        app = load_app(info.context)
 
         if payment_transactions := list(order.payment_transactions.all()):
             # We use the last transaction as we don't have a possibility to
@@ -51,7 +53,7 @@ class OrderVoid(BaseMutation):
                     info.context.plugins,
                     channel_slug=order.channel.slug,
                     user=info.context.user,
-                    app=info.context.app,
+                    app=app,
                 )
             except PaymentError as e:
                 raise ValidationError(
@@ -64,7 +66,7 @@ class OrderVoid(BaseMutation):
             transaction = try_payment_action(
                 order,
                 info.context.user,
-                info.context.app,
+                app,
                 payment,
                 gateway.void,
                 payment,
@@ -77,7 +79,7 @@ class OrderVoid(BaseMutation):
                 order_voided(
                     order,
                     info.context.user,
-                    info.context.app,
+                    app,
                     payment,
                     info.context.plugins,
                 )

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -34,6 +34,7 @@ from ...payment.gateway import (
 )
 from ...payment.utils import create_payment, is_currency_supported
 from ..account.i18n import I18nMixin
+from ..app.dataloaders import load_app
 from ..channel.utils import validate_channel
 from ..checkout.mutations.utils import get_checkout
 from ..checkout.types import Checkout
@@ -810,10 +811,11 @@ class TransactionCreate(BaseMutation):
         else:
             transaction_data["order_id"] = order_or_checkout_instance.pk
             if transaction_event_data:
+                app = load_app(info.context)
                 transaction_event(
                     order=order_or_checkout_instance,
                     user=info.context.user,
-                    app=info.context.app,
+                    app=app,
                     reference=transaction_event_data.get("reference", ""),
                     status=transaction_event_data["status"],
                     name=transaction_event_data.get("name", ""),
@@ -921,10 +923,11 @@ class TransactionUpdate(TransactionCreate):
         if transaction_event_data := data.get("transaction_event"):
             cls.create_transaction_event(transaction_event_data, instance)
             if instance.order_id:
+                app = load_app(info.context)
                 transaction_event(
                     order=instance.order,
                     user=info.context.user,
-                    app=info.context.app,
+                    app=app,
                     reference=transaction_event_data.get("reference", ""),
                     status=transaction_event_data["status"],
                     name=transaction_event_data.get("name", ""),
@@ -1001,10 +1004,11 @@ class TransactionRequestAction(BaseMutation):
             if transaction.order_id
             else transaction.checkout.channel.slug
         )
+        app = load_app(info.context)
         action_kwargs = {
             "channel_slug": channel_slug,
             "user": info.context.user,
-            "app": info.context.app,
+            "app": app,
             "transaction": transaction,
             "manager": info.context.plugins,
         }

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -28,6 +28,7 @@ from ....product.utils import delete_categories
 from ....product.utils.variants import generate_and_set_variant_name
 from ....warehouse import models as warehouse_models
 from ....warehouse.error_codes import StockErrorCode
+from ...app.dataloaders import load_app
 from ...channel import ChannelContext
 from ...channel.types import Channel
 from ...core.mutations import BaseMutation, ModelBulkDeleteMutation, ModelMutation
@@ -163,10 +164,11 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
             pk__in=draft_order_lines_data.line_pks
         ).delete()
 
+        app = load_app(info.context)
         # run order event for deleted lines
         for order, order_lines in draft_order_lines_data.order_to_lines_mapping.items():
             order_events.order_line_product_removed_event(
-                order, info.context.user, info.context.app, order_lines
+                order, info.context.user, app, order_lines
             )
 
         order_pks = draft_order_lines_data.order_pks
@@ -412,7 +414,8 @@ class ProductVariantBulkCreate(BaseMutation):
         attributes = cleaned_input.get("attributes")
         if attributes:
             AttributeAssignmentMixin.save(instance, attributes)
-            generate_and_set_variant_name(instance, cleaned_input.get("sku"))
+            if not instance.name:
+                generate_and_set_variant_name(instance, cleaned_input.get("sku"))
 
     @classmethod
     def create_variants(cls, info, cleaned_inputs, product, errors):
@@ -627,10 +630,11 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
             pk__in=draft_order_lines_data.line_pks
         ).delete()
 
+        app = load_app(info.context)
         # run order event for deleted lines
         for order, order_lines in draft_order_lines_data.order_to_lines_mapping.items():
             order_events.order_line_variant_removed_event(
-                order, info.context.user, info.context.app, order_lines
+                order, info.context.user, app, order_lines
             )
 
         order_pks = draft_order_lines_data.order_pks

--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -152,13 +152,28 @@ def api_client():
 
 @pytest.fixture
 def schema_context():
-    params = {"user": AnonymousUser(), "app": None, "plugins": get_plugins_manager()}
+    params = {
+        "user": AnonymousUser(),
+        "app": None,
+        "plugins": get_plugins_manager(),
+        "auth_token": "",
+    }
     return graphene.types.Context(**params)
 
 
 @pytest.fixture
 def info(schema_context):
     return Mock(context=schema_context)
+
+
+@pytest.fixture
+def anonymous_user():
+    return AnonymousUser()
+
+
+@pytest.fixture
+def anonymous_plugins():
+    return get_plugins_manager()
 
 
 class LoggingHandler(logging.Handler):

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from ...core.permissions import AppPermission, AuthorizationFilters
 from ...webhook import models
 from ...webhook.error_codes import WebhookErrorCode
+from ..app.dataloaders import load_app
 from ..core.descriptions import ADDED_IN_32, DEPRECATED_IN_3X_INPUT, PREVIEW_FEATURE
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types import NonNullList, WebhookError
@@ -110,7 +111,7 @@ class WebhookCreate(ModelMutation):
     @classmethod
     def get_instance(cls, info, **data):
         instance = super().get_instance(info, **data)
-        app = info.context.app
+        app = load_app(info.context)
         instance.app = app
         return instance
 
@@ -245,7 +246,7 @@ class WebhookDelete(ModelDeleteMutation):
         node_id = data["id"]
         object_id = cls.get_global_id_or_error(node_id)
 
-        app = info.context.app
+        app = load_app(info.context)
         if app:
             if not app.is_active:
                 raise ValidationError(

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -9,12 +9,13 @@ from ...core.tracing import traced_resolver
 from ...webhook import models, payloads
 from ...webhook.deprecated_event_types import WebhookEventType
 from ...webhook.event_types import WebhookEventAsyncType, WebhookEventSyncType
+from ..app.dataloaders import load_app
 from ..core.utils import from_global_id_or_error
 from .types import Webhook, WebhookEvent
 
 
 def resolve_webhook(info, id):
-    app = info.context.app
+    app = load_app(info.context)
     _, id = from_global_id_or_error(id, Webhook)
     if app:
         return app.webhooks.filter(id=id).first()
@@ -33,7 +34,7 @@ def resolve_webhook_events():
 
 @traced_resolver
 def resolve_sample_payload(info, event_name):
-    app = info.context.app
+    app = load_app(info.context)
     required_permission = WebhookEventAsyncType.PERMISSIONS.get(
         event_name, WebhookEventSyncType.PERMISSIONS.get(event_name)
     )

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -385,7 +385,8 @@ def test_send_email_order_confirmation_for_cc(
 def test_send_confirmation_emails_without_addresses_for_payment(
     mocked_notify,
     site_settings,
-    info,
+    anonymous_user,
+    anonymous_plugins,
     digital_content,
     payment_dummy,
 ):
@@ -397,11 +398,11 @@ def test_send_confirmation_emails_without_addresses_for_payment(
     )
 
     line = add_variant_to_order(
-        order,
-        line_data,
-        user=info.context.user,
-        app=info.context.app,
-        manager=info.context.plugins,
+        order=order,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
         site_settings=site_settings,
     )
     DigitalContentUrl.objects.create(content=digital_content, line=line)
@@ -412,7 +413,7 @@ def test_send_confirmation_emails_without_addresses_for_payment(
     order.save(update_fields=["shipping_address", "shipping_method", "billing_address"])
     order_info = fetch_order_info(order)
 
-    notifications.send_payment_confirmation(order_info, info.context.plugins)
+    notifications.send_payment_confirmation(order_info, anonymous_plugins)
 
     expected_payload = {
         "order": get_default_order_payload(order),
@@ -437,7 +438,12 @@ def test_send_confirmation_emails_without_addresses_for_payment(
 
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_send_confirmation_emails_without_addresses_for_order(
-    mocked_notify, order, site_settings, digital_content, info
+    mocked_notify,
+    order,
+    site_settings,
+    digital_content,
+    anonymous_user,
+    anonymous_plugins,
 ):
 
     assert not order.lines.count()
@@ -448,11 +454,11 @@ def test_send_confirmation_emails_without_addresses_for_order(
     )
 
     line = add_variant_to_order(
-        order,
-        line_data,
-        user=info.context.user,
-        app=info.context.app,
-        manager=info.context.plugins,
+        order=order,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
         site_settings=site_settings,
     )
     DigitalContentUrl.objects.create(content=digital_content, line=line)
@@ -465,9 +471,7 @@ def test_send_confirmation_emails_without_addresses_for_order(
 
     redirect_url = "https://www.example.com"
 
-    notifications.send_order_confirmation(
-        order_info, redirect_url, info.context.plugins
-    )
+    notifications.send_order_confirmation(order_info, redirect_url, anonymous_plugins)
 
     expected_payload = {
         "order": get_default_order_payload(order, redirect_url),

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -90,7 +90,13 @@ def test_recalculate_order_keeps_weight_unit(order_with_lines):
 
 
 def test_add_variant_to_order_adds_line_for_new_variant(
-    order_with_lines, product, product_translation_fr, settings, info, site_settings
+    order_with_lines,
+    product,
+    product_translation_fr,
+    settings,
+    anonymous_user,
+    anonymous_plugins,
+    site_settings,
 ):
     order = order_with_lines
     variant = product.variants.get()
@@ -99,12 +105,12 @@ def test_add_variant_to_order_adds_line_for_new_variant(
     line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=1)
 
     add_variant_to_order(
-        order,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
+        order=order,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
     )
 
     line = order.lines.last()
@@ -128,7 +134,8 @@ def test_add_variant_to_order_adds_line_for_new_variant_on_sale(
     sale,
     discount_info,
     settings,
-    info,
+    anonymous_user,
+    anonymous_plugins,
     site_settings,
 ):
     order = order_with_lines
@@ -140,13 +147,13 @@ def test_add_variant_to_order_adds_line_for_new_variant_on_sale(
     line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=1)
 
     add_variant_to_order(
-        order,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
-        [discount_info],
+        order=order,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
+        discounts=[discount_info],
     )
 
     line = order.lines.last()
@@ -171,7 +178,13 @@ def test_add_variant_to_order_adds_line_for_new_variant_on_sale(
 
 
 def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
-    order_with_lines, product, product_translation_fr, settings, info, site_settings
+    order_with_lines,
+    product,
+    product_translation_fr,
+    settings,
+    anonymous_user,
+    anonymous_plugins,
+    site_settings,
 ):
     order = order_with_lines
     variant = product.variants.get()
@@ -184,12 +197,12 @@ def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
     line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=1)
 
     add_variant_to_order(
-        order,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
+        order=order,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
     )
 
     line = order.lines.last()
@@ -203,7 +216,11 @@ def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
 
 
 def test_add_variant_to_order_not_allocates_stock_for_new_variant(
-    order_with_lines, product, info, site_settings
+    order_with_lines,
+    product,
+    anonymous_user,
+    anonymous_plugins,
+    site_settings,
 ):
     variant = product.variants.get()
     stock = Stock.objects.get(product_variant=variant)
@@ -212,12 +229,12 @@ def test_add_variant_to_order_not_allocates_stock_for_new_variant(
 
     line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=1)
     add_variant_to_order(
-        order_with_lines,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
+        order=order_with_lines,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
     )
 
     stock.refresh_from_db()
@@ -225,7 +242,7 @@ def test_add_variant_to_order_not_allocates_stock_for_new_variant(
 
 
 def test_add_variant_to_order_edits_line_for_existing_variant(
-    order_with_lines, info, site_settings
+    order_with_lines, anonymous_user, anonymous_plugins, site_settings
 ):
     existing_line = order_with_lines.lines.first()
     variant = existing_line.variant
@@ -236,12 +253,12 @@ def test_add_variant_to_order_edits_line_for_existing_variant(
     )
 
     add_variant_to_order(
-        order_with_lines,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
+        order=order_with_lines,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
     )
 
     existing_line.refresh_from_db()
@@ -252,7 +269,7 @@ def test_add_variant_to_order_edits_line_for_existing_variant(
 
 
 def test_add_variant_to_order_not_allocates_stock_for_existing_variant(
-    order_with_lines, info, site_settings
+    order_with_lines, anonymous_user, anonymous_plugins, site_settings
 ):
     existing_line = order_with_lines.lines.first()
     variant = existing_line.variant
@@ -265,12 +282,12 @@ def test_add_variant_to_order_not_allocates_stock_for_existing_variant(
     )
 
     add_variant_to_order(
-        order_with_lines,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
+        order=order_with_lines,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
     )
 
     stock.refresh_from_db()
@@ -542,17 +559,19 @@ def test_calculate_order_weight(order_with_lines):
     assert calculated_weight == order_weight
 
 
-def test_order_weight_add_more_variant(order_with_lines, info, site_settings):
+def test_order_weight_add_more_variant(
+    order_with_lines, anonymous_user, anonymous_plugins, site_settings
+):
     variant = order_with_lines.lines.first().variant
     line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=2)
 
     add_variant_to_order(
-        order_with_lines,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
+        order=order_with_lines,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
     )
     order_with_lines.refresh_from_db()
 
@@ -561,17 +580,23 @@ def test_order_weight_add_more_variant(order_with_lines, info, site_settings):
     )
 
 
-def test_order_weight_add_new_variant(order_with_lines, product, info, site_settings):
+def test_order_weight_add_new_variant(
+    order_with_lines,
+    product,
+    anonymous_user,
+    anonymous_plugins,
+    site_settings,
+):
     variant = product.variants.first()
     line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=2)
 
     add_variant_to_order(
-        order_with_lines,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
+        order=order_with_lines,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
     )
     order_with_lines.refresh_from_db()
 
@@ -605,7 +630,11 @@ def test_order_weight_delete_line(lines_info):
 
 
 def test_get_order_weight_non_existing_product(
-    order_with_lines, product, info, site_settings
+    order_with_lines,
+    product,
+    anonymous_user,
+    anonymous_plugins,
+    site_settings,
 ):
     # Removing product should not affect order's weight
     order = order_with_lines
@@ -613,12 +642,12 @@ def test_get_order_weight_non_existing_product(
     line_data = OrderLineData(variant_id=str(variant.id), variant=variant, quantity=1)
 
     add_variant_to_order(
-        order,
-        line_data,
-        info.context.user,
-        info.context.app,
-        info.context.plugins,
-        site_settings,
+        order=order,
+        line_data=line_data,
+        user=anonymous_user,
+        app=None,
+        manager=anonymous_plugins,
+        site_settings=site_settings,
     )
     old_weight = order.get_total_weight()
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -944,8 +944,10 @@ def _update_order_total_charged(order: Order):
         sum(order.payments.values_list("captured_amount", flat=True))  # type: ignore
         or 0
     )
-    order.total_charged_amount += sum(
-        order.payment_transactions.values_list("charged_value", flat=True)  # type: ignore # noqa: E501
+    order.total_charged_amount += sum(  # type: ignore
+        order.payment_transactions.values_list(  # type: ignore
+            "charged_value", flat=True
+        )
     )
 
 

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -34,6 +34,8 @@ def plugin_configuration(db, channel_USD):
         from_country_area="",
         from_postal_code="53-601",
         shipping_tax_code="FR000000",
+        override_global_tax=False,
+        include_taxes_in_prices=True,
     ):
         channel = channel or channel_USD
         data = {
@@ -52,6 +54,8 @@ def plugin_configuration(db, channel_USD):
                 {"name": "from_country_area", "value": from_country_area},
                 {"name": "from_postal_code", "value": from_postal_code},
                 {"name": "shipping_tax_code", "value": shipping_tax_code},
+                {"name": "override_global_tax", "value": override_global_tax},
+                {"name": "include_taxes_in_prices", "value": include_taxes_in_prices},
             ],
         }
         configuration = PluginConfiguration.objects.create(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -2559,7 +2559,9 @@ def test_checkout_needs_new_fetch(checkout_with_item, address, shipping_method):
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
-    checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
+    checkout_data = generate_request_data_from_checkout(
+        checkout_info, lines, config, tax_included=True
+    )
     assert taxes_need_new_fetch(checkout_data, None)
 
 
@@ -2578,7 +2580,9 @@ def test_taxes_need_new_fetch_uses_cached_data(checkout_with_item, address):
     manager = get_plugins_manager()
     lines, _ = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
-    checkout_data = generate_request_data_from_checkout(checkout_info, lines, config)
+    checkout_data = generate_request_data_from_checkout(
+        checkout_info, lines, config, tax_included=True
+    )
     assert not taxes_need_new_fetch(checkout_data, (checkout_data, None))
 
 
@@ -3382,6 +3386,8 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "from_country": conf["from_country"],
         "from_country_area": conf["from_country_area"],
         "shipping_tax_code": conf["shipping_tax_code"],
+        "override_global_tax": conf["override_global_tax"],
+        "include_taxes_in_prices": conf["include_taxes_in_prices"],
     }
 
     api_post_request_task_mock.assert_called_once_with(
@@ -3547,7 +3553,7 @@ def test_get_order_request_data_checks_when_taxes_are_included_to_price(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
     lines_data = request_data["createTransactionModel"]["lines"]
 
     assert all([line for line in lines_data if line["taxIncluded"] is True])
@@ -3588,7 +3594,9 @@ def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(
+        order_with_lines, config, tax_included=include_taxes_in_prices
+    )
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3610,7 +3618,6 @@ def test_get_order_request_data_for_line_with_already_included_taxes_in_price(
 def test_get_order_request_data_confirmed_order_with_voucher(
     order_with_lines, shipping_zone, site_settings, address, voucher
 ):
-    site_settings.include_taxes_in_prices = True
     site_settings.company_address = address
     site_settings.save()
     method = shipping_zone.shipping_methods.get()
@@ -3650,7 +3657,7 @@ def test_get_order_request_data_confirmed_order_with_voucher(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # extra one from shipping data
@@ -3697,7 +3704,7 @@ def test_get_order_request_data_confirmed_order_with_sale(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
     lines_data = request_data["createTransactionModel"]["lines"]
 
     # extra one from shipping data
@@ -3751,7 +3758,7 @@ def test_get_order_request_data_draft_order_with_voucher(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3815,7 +3822,7 @@ def test_get_order_request_data_draft_order_with_shipping_voucher(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3835,7 +3842,6 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
     """Ensure that when order has shipping voucher with price bigger than shipping
     price, the shipping price will not be negative."""
     # given
-    site_settings.include_taxes_in_prices = True
     site_settings.company_address = address
     site_settings.save()
     method = shipping_zone.shipping_methods.get()
@@ -3881,7 +3887,7 @@ def test_get_order_request_data_draft_order_shipping_voucher_amount_too_high(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3935,7 +3941,7 @@ def test_get_order_request_data_draft_order_with_sale(
     )
 
     # when
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     # then
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -3959,10 +3965,10 @@ def test_get_order_tax_data(
     get_cached_response_or_fetch_mock.return_value = return_value
 
     # when
-    response = get_order_tax_data(order, conf)
+    response = get_order_tax_data(order, conf, tax_included=True)
 
     # then
-    get_order_request_data_mock.assert_called_once_with(order, conf)
+    get_order_request_data_mock.assert_called_once_with(order, conf, True)
     assert response == return_value
 
 
@@ -3982,7 +3988,7 @@ def test_get_order_tax_data_raised_error(
 
     # when
     with pytest.raises(TaxError) as e:
-        get_order_tax_data(order, conf)
+        get_order_tax_data(order, conf, tax_included=True)
 
     # then
     assert e._excinfo[1].args[0] == return_value["error"]
@@ -4072,7 +4078,9 @@ def test_get_checkout_lines_data_sets_different_tax_code_for_zero_amount(
     config = avatax_config
 
     # when
-    lines_data = get_checkout_lines_data(checkout_info, lines, config)
+    lines_data = get_checkout_lines_data(
+        checkout_info, lines, config, tax_included=True
+    )
 
     # then
     assert lines_data[0]["amount"] == "0.00"
@@ -4105,7 +4113,9 @@ def test_get_checkout_lines_data_sets_different_tax_code_only_for_zero_amount(
     config = avatax_config
 
     # when
-    lines_data = get_checkout_lines_data(checkout_info, lines, config)
+    lines_data = get_checkout_lines_data(
+        checkout_info, lines, config, tax_included=True
+    )
 
     # then
     assert lines_data[0]["amount"] == "11.00"
@@ -4146,7 +4156,9 @@ def test_get_checkout_lines_data_with_collection_point(
     config = avatax_config
 
     # when
-    lines_data = get_checkout_lines_data(checkout_info, lines, config)
+    lines_data = get_checkout_lines_data(
+        checkout_info, lines, config, tax_included=True
+    )
 
     # then
     assert len(lines_data) == checkout_with_item.lines.count()
@@ -4186,7 +4198,9 @@ def test_get_checkout_lines_data_with_shipping_method(
     config = avatax_config
 
     # when
-    lines_data = get_checkout_lines_data(checkout_info, lines, config)
+    lines_data = get_checkout_lines_data(
+        checkout_info, lines, config, tax_included=True
+    )
 
     # then
     assert len(lines_data) == checkout_with_item.lines.count() + 1
@@ -4227,7 +4241,9 @@ def test_get_order_lines_data_sets_different_tax_code_for_zero_amount(
     )
 
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(
+        order_with_lines, config, tax_included=True, discounted=False
+    )
 
     # then
     assert lines_data[0]["amount"] == "0.000"
@@ -4269,7 +4285,7 @@ def test_get_order_lines_data_with_discounted(
     )
 
     # when
-    lines_data = get_order_lines_data(order, config, discounted=True)
+    lines_data = get_order_lines_data(order, config, tax_included=True, discounted=True)
 
     # then
     assert len(lines_data) == 1
@@ -4305,7 +4321,9 @@ def test_get_order_lines_data_sets_different_tax_code_only_for_zero_amount(
     config = avatax_config
 
     # when
-    lines_data = get_order_lines_data(order_with_lines, config, discounted=False)
+    lines_data = get_order_lines_data(
+        order_with_lines, config, tax_included=True, discounted=False
+    )
 
     # then
     assert lines_data[0]["amount"] == "10.000"
@@ -4412,3 +4430,40 @@ def test_assign_tax_code_to_object_meta_no_obj_id(
         META_CODE_KEY: tax_code,
         META_DESCRIPTION_KEY: description,
     }
+
+
+@pytest.mark.parametrize(
+    "global_include_taxes_in_prices, override_global_tax, "
+    "include_taxes_in_prices, expected_tax_included",
+    [(True, False, False, True), (True, True, True, True), (True, True, False, False)],
+)
+@patch("saleor.plugins.avatax.plugin.api_post_request_task.delay")
+@override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
+def test_plugin_tax_override_setting(
+    api_post_request_task_mock,
+    global_include_taxes_in_prices,
+    override_global_tax,
+    include_taxes_in_prices,
+    expected_tax_included,
+    site_settings,
+    order_line,
+    plugin_configuration,
+):
+    # given
+    site_settings.include_taxes_in_prices = global_include_taxes_in_prices
+    site_settings.save()
+
+    plugin_configuration(
+        override_global_tax=override_global_tax,
+        include_taxes_in_prices=include_taxes_in_prices,
+    )
+
+    manager = get_plugins_manager()
+
+    # when
+    manager.order_created(order_line.order)
+
+    # then
+    transaction = api_post_request_task_mock.call_args[0][1]["createTransactionModel"]
+    transaction_line = transaction["lines"][0]
+    assert transaction_line["taxIncluded"] == expected_tax_included

--- a/saleor/plugins/avatax/tests/test_avatax_caching.py
+++ b/saleor/plugins/avatax/tests/test_avatax_caching.py
@@ -33,7 +33,7 @@ def test_calculate_checkout_total_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -94,7 +94,7 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("72.2", "USD"), gross=Money("75", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -122,7 +122,7 @@ def test_calculate_checkout_subtotal_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -183,7 +183,7 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("64.07", "USD"), gross=Money("65", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -211,7 +211,7 @@ def test_calculate_checkout_shipping_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -272,7 +272,7 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("8.13", "USD"), gross=Money("10", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -301,7 +301,7 @@ def test_calculate_checkout_line_total_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -363,7 +363,7 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -392,7 +392,7 @@ def test_calculate_checkout_line_unit_price_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -466,7 +466,7 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     assert result == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5", "USD"))
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -495,7 +495,7 @@ def test_get_checkout_line_tax_rate_use_cache(
     lines, _ = fetch_checkout_lines(checkout)
     checkout_line_info = lines[0]
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -574,7 +574,7 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     assert result == Decimal("0.36")
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)
 
@@ -602,7 +602,7 @@ def test_get_checkout_shipping_tax_rate_use_cache(
     site_settings.save()
     lines, _ = fetch_checkout_lines(checkout)
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_cache = Mock(
         return_value=(
@@ -665,6 +665,6 @@ def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
     assert result == Decimal("0.46")
 
     avalara_request_data = generate_request_data_from_checkout(
-        checkout_info, lines, plugin.config, []
+        checkout_info, lines, plugin.config, tax_included=True, transaction_token=[]
     )
     mocked_avalara.assert_called_once_with(ANY, avalara_request_data, plugin.config)

--- a/saleor/plugins/avatax/tests/test_tasks.py
+++ b/saleor/plugins/avatax/tests/test_tasks.py
@@ -30,7 +30,7 @@ def test_api_post_request_task_sends_request(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"
@@ -62,7 +62,7 @@ def test_api_post_request_task_creates_order_event(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"
@@ -95,7 +95,7 @@ def test_api_post_request_task_missing_response(
         from_postal_code="53-601",
         from_country="PL",
     )
-    request_data = get_order_request_data(order_with_lines, config)
+    request_data = get_order_request_data(order_with_lines, config, tax_included=True)
 
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"

--- a/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
+++ b/saleor/plugins/webhook/tests/subscription_webhooks/test_create_deliveries_for_subscription.py
@@ -43,12 +43,16 @@ from .payloads import (
 @freeze_time("2022-05-12 12:00:00")
 @pytest.mark.parametrize("requestor_type", ["user", "app", None, "anonymous"])
 def test_subscription_query_with_meta(
-    requestor_type, voucher, staff_user, app, subscription_voucher_webhook_with_meta
+    requestor_type,
+    voucher,
+    staff_user,
+    app_with_token,
+    subscription_voucher_webhook_with_meta,
 ):
     # given
     requestor_map = {
         "user": staff_user,
-        "app": app,
+        "app": app_with_token,
         None: None,
         "anonymous": AnonymousUser(),
     }

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -28,7 +28,7 @@ from PIL import Image
 from prices import Money, TaxedMoney, fixed_discount
 
 from ..account.models import Address, StaffNotificationRecipient, User
-from ..app.models import App, AppExtension, AppInstallation
+from ..app.models import App, AppExtension, AppInstallation, AppToken
 from ..app.types import AppExtensionMount, AppType
 from ..attribute import AttributeEntityType, AttributeInputType, AttributeType
 from ..attribute.models import (
@@ -2483,7 +2483,6 @@ def product_with_variant_with_file_attribute(
 
 @pytest.fixture
 def product_with_multiple_values_attributes(product, product_type, category) -> Product:
-
     attribute = Attribute.objects.create(
         slug="modes",
         name="Available Modes",
@@ -4385,7 +4384,8 @@ def draft_order_with_fixed_discount_order(draft_order):
         value_type=DiscountValueType.FIXED,
         value=value,
         reason="Discount reason",
-        amount=(draft_order.undiscounted_total - draft_order.total).gross,  # type: ignore
+        amount=(draft_order.undiscounted_total - draft_order.total).gross,
+        # type: ignore
     )
     draft_order.save()
     return draft_order


### PR DESCRIPTION
* App dataloader

* Fix getting user from context/request

* Change base clas

* Start removing context.app

* Portion of changes

* Removed context.app

* Marked places for deeper investigation

* Fix AppByTokenDataLoader to return properly prepared result.

* Removing context.app from tests

* Remove unneeded info from some tests

* Remove context.app from address resolver

* Add fixtures for app with token

* Refactor get_app to dataloader

* Remove some more context.app appearances.

* Little cleanup

* Fix typehints

* Add note to changelog

* Cleanup after CR

* Improve AppByTokenLoader

* Fixes after CR

* Silence mypy error

* Temporarily raise query count in a test

* Update saleor/graphql/app/dataloaders.py

Co-authored-by: Filip Owczarek <filip.owczarek@defectprediction.net>

* Add typehints and explanation to create_with_token method

* Another context.app occurence removed; removed unnecessary fixture

* Move get_app to more proper place

* Another context.app removed but increased query count in test

* Cleanup fixtures

* Revert Event.resolve_recipient method - will be fixed in next iteration along with context.requestor

* Substitute request.app lazy model with app dataloader; revert number of queries back to previous levels

* Remove a resolved TODO from code

* Remove unused function