### PR TITLE
Add ability to filter by slug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable, unreleased changes to this project will be documented in this file.
 
 # 3.8.0 [Unreleased]
 
+### GraphQL API
+- Add ability to filter by slug. #10578 by @kadewu
+  - Affected types: Attribute, Category, Collection, Menu, Page, Product, ProductType, Warehouse
+  - Deprecated `slug` in filter for `menus`. Use `slugs` instead
+
 ### Other changes
 
 - Reference attribute linking to product variants - #10468 by @IKarbowiak


### PR DESCRIPTION
* Add filter by slug

Slug filter was added to endpoints:
- products
- collections
- categories
- pages

* Move slug filter to core

* Add filter by slug to more queries

queries:
- attributes
- warehouses
- menus
- productTypes
- pageTypes

* Update CHANGELOG

* Add depricated reason to menu slug