### PR TITLE
Add and correct type information

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ exclude_lines =
     raise NotImplementedError
     return NotImplemented
     if TYPE_CHECKING:
+    @overload
 
 [tool:pytest]
 addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket
@@ -50,13 +51,21 @@ inherit = false
 match-dir = saleor
 
 [mypy]
-ignore_missing_imports = True
 allow_untyped_globals = True
 allow_redefinition = True
+check_untyped_defs = True
+ignore_missing_imports = True
+pretty = True
+show_column_numbers = True
 show_error_codes = True
+warn_redundant_casts = True
+warn_unused_ignores = True
 
 plugins =
     mypy_django_plugin.main
+
+exclude =
+    \/tests\/
 
 [mypy.plugins.django-stubs]
 django_settings_module = saleor.settings


### PR DESCRIPTION
This touches a significant part of the codebase to add missing type information and to introduce automated type inference for common functions returning different object types based on parameters.