### PR TITLE
Attribute filters improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Breaking changes
 
+### Preview
+- Add new error handling policies in `ProductVariantBulkCreate`- #11392 by @SzymJ
+- Add `ProductVariantBulkUpdate` mutation - #11392 by @SzymJ
+
 ### GraphQL API
 
 - Add `webhookDryRun` mutation - #11548 by @zedzior
 - Fix adding invalid label to meta fields - #11718 by @IKarbowiak
 - Add filter by `checkoutToken` to `Query.orders`. - #11689 by @kadewu
 - Add `WebhookTrigger` mutation - #11687 by @zedzior
+- Attribute filters improvement - #11737 by @IKarbowiak
+  - introduce `where` option on `attributes` query
+  - add `search` option on `attributes` query
+  - deprecate `product.variant` field
+  - deprecate the following `Attribute` fields: `filterableInStorefront`, `storefrontSearchPosition`, `availableInGrid`.
 
 ### Other changes
 - Allow `webhookCreate` and `webhookUpdate` mutations to inherit events from `query` field - #11736 by @zedzior


### PR DESCRIPTION
* Introduce attribute where filtering

* Add support for AND, OR, NOT operators

* Refactor filter methods for connection

* Add tests for attribute where filters

* Add ids to AttributeWhereInput, and add test for filtering by attribute ids

* Deprecate attribute fields: filterableInStorefront, storefrontSearchPosition, availableInGrid

* Add generic FilterInputObjectType for where filters

* Do not allow providing both filter and where options in query

* User range input field in IntFilterInput, DateFilterInput, and DateTimeFilterInput

* Do not allow providing multiple operation options in where filter

* Allow providing nested where filter conditions

* Update  labels in new fields

* Add  on attributes query root level

* Deprecare product.variant field

* Update changelog

* Clear AttributeWhere meta fields

* Add where filtering options to nested connections fields of Attribute type

* Add indexes to Attribute model

* Get rid of distinct on attributes resolver

* Fix failing test for ids where filtering

* Comment NOT operator - it needs optimization

* Drop unused method