### PR TITLE
Move orderSetting to Channel type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ All notable, unreleased changes to this project will be documented in this file.
 ### Breaking changes
 
 ### GraphQL API
+- Move `orderSettings` query to `Channel` type - #11417 by @kadewu:
+  - Mutation `Channel.channelCreate` and `Channel.channelUpdate` have new `orderSettings` input.
+  - Deprecate `Shop.orderSettings` query. Use `Channel.orderSettings` query instead.
+  - Deprecate `Shop.orderSettingsUpdate` mutation. Use `Channel.channelUpdate` instead.
+
 
 ### Other changes
 
 - Enhance webhook's subscription query validation. Apply the validation and event inheritance to manifest validation - #11797 by @zedzior
+- Fix GraphQL playground when the `operationName` is set across different tabs - #11936 by @zaiste
 
 # 3.11.0
 
@@ -48,7 +54,6 @@ Just so you know, changes mentioned in this section are in a preview state and c
 ### Breaking changes
 
 ### GraphQL API
-
 - Add ability to filter and sort products of a category - #10917 by @yemeksepeti-cihankarluk, @ogunheper
   - Add `filter` argument to `Category.products`
   - Add `sortBy` argument to `Category.products`


### PR DESCRIPTION
* Move orderSetting to Channel type

Update changelog

Add additional permission to channel_update

Permission MANAGE_ORDERS will be taken into account, when mutation
contains only orderSetting input

Remove orderSettings fields from settings

Ensure no downtime in migration

* Update changelogs

* Update schema descriptions

* Ensure that all data is properly migrated