### PR TITLE
Handle CORS at ASGI level

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,8 @@ exclude_lines =
     @overload
 
 [tool:pytest]
-addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket
+addopts = -n auto --record-mode=none --ds=saleor.tests.settings --disable-socket --allow-unix-socket
+asyncio_mode = auto
 testpaths = saleor
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
This is faster than doing it inside the Django view but,
like the health check, it won't work with `manage.py runserver`.