### PR TITLE
Bump cacheable-request and release-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "http://saleor.io/",
   "devDependencies": {
     "@release-it/bumper": "^4.0.0",
-    "release-it": "^15.4.2"
+    "release-it": "^15.6.0"
   },
   "scripts": {
     "build-schema": "python manage.py get_graphql_schema > saleor/graphql/schema.graphql",


### PR DESCRIPTION
Bumps [cacheable-request](https://github.com/jaredwray/cacheable-request) to 10.2.7 and updates ancestor dependency [release-it](https://github.com/release-it/release-it). These dependencies need to be updated together.


Updates `cacheable-request` from 7.0.2 to 10.2.7
- [Release notes](https://github.com/jaredwray/cacheable-request/releases)
- [Commits](https://github.com/jaredwray/cacheable-request/commits)

Updates `release-it` from 15.4.2 to 15.6.0
- [Release notes](https://github.com/release-it/release-it/releases)
- [Changelog](https://github.com/release-it/release-it/blob/master/CHANGELOG.md)
- [Commits](https://github.com/release-it/release-it/compare/15.4.2...15.6.0)

---
updated-dependencies:
- dependency-name: cacheable-request
  dependency-type: indirect
- dependency-name: release-it
  dependency-type: direct:development
...